### PR TITLE
Qrexec policy daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
        - pip install --quiet codecov
        - docker build -t qrexec-test ci
       env: DOCKER_RUN="docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -v /tmp/.X11-unix:/tmp/.X11-unix -w $TRAVIS_BUILD_DIR -e DISPLAY=$DISPLAY -- qrexec-test"
-      script: $DOCKER_RUN python3 -m coverage run -m unittest discover -s qrexec/tests -t . -p '*.py' -v
+      script: $DOCKER_RUN python3 -m coverage run -m pytest qrexec/tests -o python_files=*.py -v
 #    - python: '3.7'
 #      script: python -m coverage run -m unittest discover -s qrexec/tests -t . -p '*.py' -v
     - stage: deploy

--- a/Documentation/qrexec-policy-daemon.rst
+++ b/Documentation/qrexec-policy-daemon.rst
@@ -1,0 +1,33 @@
+Qubes Policy Request Daemon
+===========================
+
+Protocol
+^^^^^^^^
+
+Request
+-------
+
+Newline-separated:
+
+- domain_id=
+- source=
+- intended_target=
+- service_and_arg=
+- process_ident=
+
+Optional arguments:
+
+- assume_yes_for_ask=yes
+- just_evaluate=yes
+
+
+Response
+--------
+
+`result=allow/deny`
+
+Any possible extensions may be placed on next lines.
+All responses that do not start with `result=allow` or `result=deny` are
+incorrect and will be rejected.
+
+End of response and request is always an empty line.

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ install-dom0:
 	install -d $(DESTDIR)/etc/qubes/policy.d -m 775
 	install -d $(DESTDIR)/etc/qubes/policy.d/include -m 775
 	install -t $(DESTDIR)/etc/qubes/policy.d -m 664 policy.d/*
+	install -d $(DESTDIR)/lib/systemd/system -m 755
+	install -t $(DESTDIR)/lib/systemd/system -m 644 systemd/qubes-qrexec-policy-daemon.service
 .PHONY: install-dom0
 
 
@@ -48,7 +50,7 @@ all-vm:
 install-vm:
 	$(MAKE) install -C agent
 	install -d $(DESTDIR)/lib/systemd/system -m 755
-	install -t $(DESTDIR)/lib/systemd/system -m 644 systemd/*
+	install -t $(DESTDIR)/lib/systemd/system -m 644 systemd/qubes-qrexec-agent.service
 	install -m 0644 -D qubes-rpc-config/README $(DESTDIR)/etc/qubes/rpc-config/README
 #	install -d $(DESTDIR)/etc/qubes-rpc -m 755
 #	install -t $(DESTDIR)/etc/qubes-rpc -m 755 qubes-rpc/*

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -5,3 +5,4 @@ pylint
 sphinx
 codecov
 pydbus
+pytest-asyncio

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -6,3 +6,4 @@ sphinx
 codecov
 pydbus
 pytest-asyncio
+asynctest

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -7,3 +7,4 @@ codecov
 pydbus
 pytest-asyncio
 asynctest
+pyinotify

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  */
+#define _GNU_SOURCE
 
 #include <sys/select.h>
 #include <stdio.h>
@@ -28,12 +29,17 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <err.h>
 #include <string.h>
 #include <assert.h>
 #include "qrexec.h"
 #include "libqrexec-utils.h"
 
 #define QREXEC_MIN_VERSION QREXEC_PROTOCOL_V2
+#define QREXEC_SOCKET_PATH "/var/run/qubes/policy.sock"
+
 
 enum client_state {
     CLIENT_INVALID = 0,	// table slot not used
@@ -678,6 +684,73 @@ static void sanitize_name(char * untrusted_s_signed, char *extra_allowed_chars)
  * Called when agent sends a message asking to execute a predefined command.
  */
 
+static int connect_daemon_socket(
+        const int remote_domain_id,
+        const char *remote_domain_name,
+        const char *target_domain,
+        const char *service_name,
+        const struct service_params *request_id
+) {
+    int result;
+    int command_size;
+    char response[32];
+    char *command;
+    int daemon_socket;
+    struct sockaddr_un daemon_socket_address = {
+        .sun_family = AF_UNIX,
+        .sun_path = QREXEC_SOCKET_PATH
+    };
+
+    daemon_socket = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (daemon_socket < 0) {
+         perror("socket creation failed");
+         return -1;
+    }
+
+    result = connect(daemon_socket, (struct sockaddr *) &daemon_socket_address,
+            sizeof(daemon_socket_address));
+    if (result < 0) {
+         perror("connection to socket failed");
+         return -1;
+    }
+
+    command_size = asprintf(&command, "domain_id=%d\n"
+        "source=%s\n"
+        "intended_target=%s\n"
+        "service_and_arg=%s\n"
+        "process_ident=%s\n\n",
+        remote_domain_id, remote_domain_name, target_domain,
+        service_name, request_id->ident);
+    if (command_size < 0) {
+         perror("failed to construct request");
+         return -1;
+    }
+
+    result = send(daemon_socket, command, command_size, 0);
+    free(command);
+    if (result < 0) {
+         perror("send to socket failed");
+         return -1;
+    }
+
+    result = recv(daemon_socket, response, sizeof(response), 0);
+    if (result < 0) {
+         perror("error reading from socket");
+         return -1;
+    }
+    else {
+        if (!strncmp(response, "result=allow\n", sizeof("result=allow\n")-1)) {
+            return 0;
+        } else if (!strncmp(response, "result=deny\n", sizeof("result=deny\n")-1)) {
+            return 1;
+        } else {
+            warnx("invalid response");
+            return -1;
+        }
+    }
+}
+
+
 static void handle_execute_service(
         const int remote_domain_id,
         const char *remote_domain_name,
@@ -686,6 +759,7 @@ static void handle_execute_service(
         const struct service_params *request_id)
 {
     int i;
+    int result;
     int policy_pending_slot;
     pid_t pid;
     char remote_domain_id_str[10];
@@ -708,6 +782,15 @@ static void handle_execute_service(
             policy_pending[policy_pending_slot].params = *request_id;
             return;
     }
+
+    result = connect_daemon_socket(remote_domain_id, remote_domain_name,
+                                   target_domain, service_name, request_id);
+    if (result >= 0) {
+        _exit(result);
+    } else {
+        warnx("invalid response");
+    }
+
     for (i = 3; i < MAX_FDS; i++)
         close(i);
     signal(SIGCHLD, SIG_DFL);
@@ -724,6 +807,7 @@ static void handle_execute_service(
     perror("execl");
     _exit(1);
 }
+
 
 static void handle_connection_terminated()
 {

--- a/debian/qubes-core-qrexec.install
+++ b/debian/qubes-core-qrexec.install
@@ -6,6 +6,7 @@ usr/bin/qrexec-fork-server
 usr/bin/qrexec-policy-graph
 usr/bin/qrexec-policy-restore
 usr/bin/qrexec-policy-exec
+usr/bin/qrexec-policy-daemon
 usr/bin/qrexec-policy
 usr/bin/qrexec-policy-agent
 usr/bin/qubes-policy

--- a/qrexec/__init__.py
+++ b/qrexec/__init__.py
@@ -52,6 +52,7 @@ QUBESD_INTERNAL_SOCK = '/var/run/qubesd.internal.sock'
 QUBESD_SOCK = '/var/run/qubesd.sock'
 
 POLICYPATH = pathlib.Path('/etc/qubes/policy.d')
+POLICYSOCKET = pathlib.Path('/var/run/qubes/policy.sock')
 INCLUDEPATH = POLICYPATH / 'include'
 POLICYSUFFIX = '.policy'
 POLICYPATH_OLD = pathlib.Path('/etc/qubes-rpc/policy')

--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -32,6 +32,7 @@ import logging
 import pathlib
 import string
 import subprocess
+import asyncio
 
 from typing import (
     Iterable,
@@ -459,7 +460,7 @@ class AbstractResolution(metaclass=abc.ABCMeta):
         self.user = user
 
     @abc.abstractmethod
-    def execute(self, caller_ident):
+    async def execute(self, caller_ident):
         '''
         Execute the action. For allow, this runs the qrexec. For ask, it asks
         user and then (depending on verdict) runs the call.
@@ -486,7 +487,7 @@ class AllowResolution(AbstractResolution):
             user=ask_resolution.user,
             target=target)
 
-    def execute(self, caller_ident):
+    async def execute(self, caller_ident):
         '''Execute the allowed action'''
         assert self.target is not None
 
@@ -512,7 +513,9 @@ class AllowResolution(AbstractResolution):
         if dispvm:
             qrexec_opts.append('-W')
         try:
-            subprocess.call([QREXEC_CLIENT] + qrexec_opts + [cmd])
+            command = [QREXEC_CLIENT] + qrexec_opts + [cmd]
+            process = await asyncio.create_subprocess_exec(*command)
+            await process.communicate()
         finally:
             if dispvm:
                 self.cleanup_dispvm(target)
@@ -614,7 +617,7 @@ class AskResolution(AbstractResolution):
         return self.request.allow_resolution_type.from_ask_resolution(self,
             target=target)
 
-    def execute(self, caller_ident):
+    async def execute(self, caller_ident):
         '''Ask the user for permission.
 
         This method should be overloaded in children classes. This
@@ -1357,7 +1360,7 @@ class FilePolicy(AbstractFileSystemLoader, AbstractPolicy):
     ...     'qrexec.Service', '+argument', 'source-name', 'target-name',
     ...     system_info=qrexec.utils.get_system_info())
     >>> resolution = policy.evaluate(request)
-    >>> resolution.execute('process-ident')
+    >>> await resolution.execute('process-ident')  # asynchroneous method
     '''
 
     def handle_compat40(self, *, filepath, lineno):

--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -31,7 +31,6 @@ import itertools
 import logging
 import pathlib
 import string
-import subprocess
 import asyncio
 
 from typing import (
@@ -631,7 +630,7 @@ class AskResolution(AbstractResolution):
 #
 # request
 #
-
+#pylint: disable=too-many-instance-attributes
 class Request:
     '''Qrexec request
 

--- a/qrexec/policy/utils.py
+++ b/qrexec/policy/utils.py
@@ -24,14 +24,17 @@ from . import parser
 
 
 class PolicyCache:
-    def __init__(self, path):
+    def __init__(self, path, use_legacy=True):
         self.path = path
         self.outdated = False
         self.policy = parser.FilePolicy(policy_path=self.path)
 
         # default policy paths are listed manually, for compatibility with R4.0
         # to be removed in Qubes 5.0
-        self.default_policy_paths = [str(POLICYPATH), str(POLICYPATH_OLD)]
+        if use_legacy:
+            self.default_policy_paths = [str(POLICYPATH), str(POLICYPATH_OLD)]
+        else:
+            self.default_policy_paths = []
 
         self.watch_manager = None
         self.watches = []

--- a/qrexec/policy/utils.py
+++ b/qrexec/policy/utils.py
@@ -1,0 +1,87 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2019 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+import asyncio
+import pyinotify
+from qrexec import POLICYPATH, POLICYPATH_OLD
+from . import parser
+
+
+class PolicyCache:
+    def __init__(self, path):
+        self.path = path
+        self.outdated = False
+        self.policy = parser.FilePolicy(policy_path=self.path)
+
+        # default policy paths are listed manually, for compatibility with R4.0
+        # to be removed in Qubes 5.0
+        self.default_policy_paths = [str(POLICYPATH), str(POLICYPATH_OLD)]
+
+        self.watch_manager = None
+        self.watches = []
+        self.notifier = None
+
+    def initialize_watcher(self):
+        self.watch_manager = pyinotify.WatchManager()
+
+        # pylint: disable=no-member
+        mask = pyinotify.IN_CREATE | pyinotify.IN_DELETE | pyinotify.IN_MODIFY
+
+        loop = asyncio.get_event_loop()
+
+        self.notifier = pyinotify.AsyncioNotifier(
+            self.watch_manager, loop, default_proc_fun=PolicyWatcher(self))
+
+        if str(self.path) not in self.default_policy_paths:
+            self.watches.append(
+                self.watch_manager.add_watch(
+                    str(self.path), mask, rec=True, auto_add=True))
+
+        for path in self.default_policy_paths:
+            self.watches.append(
+                self.watch_manager.add_watch(str(path), mask,
+                                             rec=True, auto_add=True))
+
+    def cleanup(self):
+        for wdd in self.watches:
+            self.watch_manager.rm_watch(wdd.values())
+
+        self.notifier.stop()
+
+    def get_policy(self):
+        if self.outdated:
+            self.policy = parser.FilePolicy(policy_path=self.path)
+            self.outdated = False
+
+        return self.policy
+
+
+class PolicyWatcher(pyinotify.ProcessEvent):
+    def __init__(self, cache):
+        self.cache = cache
+        super(PolicyWatcher, self).__init__()
+
+    def process_IN_CREATE(self, _):
+        self.cache.outdated = True
+
+    def process_IN_DELETE(self, _):
+        self.cache.outdated = True
+
+    def process_IN_MODIFY(self, _):
+        self.cache.outdated = True

--- a/qrexec/tests/cli.py
+++ b/qrexec/tests/cli.py
@@ -91,13 +91,10 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ['--path=' + self.policy_dir.name,
              'source-id', 'source', 'target', 'service', 'process_ident'])
         self.assertEqual(retval, 0)
-
-        print(self.policy_mock.mock_calls)
         self.assertEqual(self.policy_mock.mock_calls, [
             ('', (), {'policy_path': PosixPath(self.policy_dir.name)}),
             ('().evaluate', (self.request_mock(),), {}),
             ('().evaluate().execute', ('process_ident,source,source-id', ), {}),
-            ('().evaluate().target.__str__', (), {}),
         ])
         # remove call used above:
         del self.request_mock.mock_calls[-1]
@@ -290,7 +287,6 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', (), {'policy_path': PosixPath(self.policy_dir.name)}),
             ('().evaluate', (self.request_mock(),), {}),
             ('().evaluate().execute', ('process_ident,source,source-id',), {}),
-            ('().evaluate().target.__str__', (), {}),
         ])
         # remove call used above:
         del self.request_mock.mock_calls[-1]
@@ -378,6 +374,5 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', (), {'policy_path': PosixPath(self.policy_dir.name)}),
             ('().evaluate', (self.request_mock(),), {}),
             ('().evaluate().execute', ('process_ident,source,source-id', ), {}),
-            ('().evaluate().target.__str__', (), {}),
         ])
         self.assertEqual(self.dbus_mock.mock_calls, [])

--- a/qrexec/tests/cli.py
+++ b/qrexec/tests/cli.py
@@ -18,17 +18,19 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
 
-import os
 import tempfile
 import unittest.mock
 from pathlib import PosixPath
+import asynctest
 
-from .. import utils
 from ..policy import parser
 from ..tools import qrexec_policy_exec
 
 
 class TC_00_qrexec_policy(unittest.TestCase):
+    async def async_none(self, *_args, **_kwargs):
+        pass
+
     def setUp(self):
         super(TC_00_qrexec_policy, self).setUp()
         self.system_info = {
@@ -41,7 +43,8 @@ class TC_00_qrexec_policy(unittest.TestCase):
             'qrexec.policy.parser.FilePolicy')
         self.policy_mock = self.policy_patch.start()
         self.policy_mock.configure_mock(**{
-            'return_value.evaluate.return_value.execute.return_value': None
+            'return_value.evaluate.return_value.execute.side_effect':
+                self.async_none
         })
 
         self.request_patch = unittest.mock.patch(
@@ -53,6 +56,7 @@ class TC_00_qrexec_policy(unittest.TestCase):
             'return_value.service': 'service',
             'return_value.argument': 'argument',
             'return_value.system_info': self.system_info,
+            'return_value.allow_resolution_type.from_ask_resolution.return_value.execute.side_effect': asynctest.CoroutineMock(**{"return_value.target":unittest.mock.Mock()}),
         })
 
         self.system_info_patch = unittest.mock.patch(
@@ -87,6 +91,8 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ['--path=' + self.policy_dir.name,
              'source-id', 'source', 'target', 'service', 'process_ident'])
         self.assertEqual(retval, 0)
+
+        print(self.policy_mock.mock_calls)
         self.assertEqual(self.policy_mock.mock_calls, [
             ('', (), {'policy_path': PosixPath(self.policy_dir.name)}),
             ('().evaluate', (self.request_mock(),), {}),
@@ -99,10 +105,9 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', ('service', '+', 'source', 'target'), {
                 'system_info': self.system_info,
                 'ask_resolution_type': qrexec_policy_exec.DBusAskResolution,
-                'allow_resolution_type': parser.AllowResolution,
+                'allow_resolution_type':  qrexec_policy_exec.LogAllowedResolution,
             })
         ])
-        self.assertEqual(self.dbus_mock.mock_calls, [])
 
     def test_010_ask_allow(self):
         rule_mock = unittest.mock.Mock()
@@ -130,13 +135,12 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', ('service', '+', 'source', 'target'), {
                 'system_info': self.system_info,
                 'ask_resolution_type': qrexec_policy_exec.DBusAskResolution,
-                'allow_resolution_type': parser.AllowResolution,
+                'allow_resolution_type': qrexec_policy_exec.LogAllowedResolution,
             }),
             ('().allow_resolution_type.from_ask_resolution',
                 (unittest.mock.ANY, ), {'target': 'test-vm1'}),
             ('().allow_resolution_type.from_ask_resolution().execute',
                 ('process_ident,source,source-id', ), {}),
-            ('().allow_resolution_type.from_ask_resolution().execute().target.__str__', (), {})
         ])
         icons = {
             'dom0': 'black',
@@ -179,7 +183,7 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', ('service', '+', 'source', 'target'), {
                 'system_info': self.system_info,
                 'ask_resolution_type': qrexec_policy_exec.DBusAskResolution,
-                'allow_resolution_type': parser.AllowResolution,
+                'allow_resolution_type': qrexec_policy_exec.LogAllowedResolution,
             }),
         ])
         icons = {
@@ -223,13 +227,12 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', ('service', '+', 'source', 'target'), {
                 'system_info': self.system_info,
                 'ask_resolution_type': qrexec_policy_exec.DBusAskResolution,
-                'allow_resolution_type': parser.AllowResolution,
+                'allow_resolution_type': qrexec_policy_exec.LogAllowedResolution,
             }),
             ('().allow_resolution_type.from_ask_resolution',
                 (unittest.mock.ANY, ), {'target': 'test-vm1'}),
             ('().allow_resolution_type.from_ask_resolution().execute',
                 ('process_ident,source,source-id', ), {}),
-            ('().allow_resolution_type.from_ask_resolution().execute().target.__str__', (), {})
         ])
         icons = {
             'dom0': 'black',
@@ -268,7 +271,7 @@ class TC_00_qrexec_policy(unittest.TestCase):
             ('', ('service', '+', 'source', 'target'), {
                 'system_info': self.system_info,
                 'ask_resolution_type': qrexec_policy_exec.DBusAskResolution,
-                'allow_resolution_type': parser.AllowResolution,
+                'allow_resolution_type': qrexec_policy_exec.LogAllowedResolution,
             }),
         ])
         self.assertEqual(self.dbus_mock.mock_calls, [])

--- a/qrexec/tests/policy_cache.py
+++ b/qrexec/tests/policy_cache.py
@@ -1,0 +1,120 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2019 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+
+import os
+import asyncio
+import pytest
+import unittest
+import unittest.mock
+
+from ..policy import utils
+
+
+class TestPolicyCache:
+    @pytest.fixture
+    def mock_parser(self, monkeypatch):
+        mock_parser = unittest.mock.Mock()
+        monkeypatch.setattr('qrexec.policy.utils.parser.FilePolicy',
+                            mock_parser)
+        return mock_parser
+
+    def test_00_policy_init(self, tmp_path, mock_parser):
+        cache = utils.PolicyCache(tmp_path)
+        mock_parser.assert_called_once_with(policy_path=tmp_path)
+
+    @pytest.mark.asyncio
+    async def test_10_file_created(self, tmp_path, mock_parser):
+        cache = utils.PolicyCache(tmp_path)
+        cache.initialize_watcher()
+
+        assert not cache.outdated
+
+        file = tmp_path / "test"
+        file.write_text("test")
+
+        await asyncio.sleep(1)
+
+        assert cache.outdated
+
+    @pytest.mark.asyncio
+    async def test_11_file_changed(self, tmp_path, mock_parser):
+        file = tmp_path / "test"
+        file.write_text("test")
+
+        cache = utils.PolicyCache(tmp_path)
+        cache.initialize_watcher()
+
+        assert not cache.outdated
+
+        file.write_text("new_content")
+
+        await asyncio.sleep(1)
+
+        assert cache.outdated
+
+    @pytest.mark.asyncio
+    async def test_12_file_deleted(self, tmp_path, mock_parser):
+        file = tmp_path / "test"
+        file.write_text("test")
+
+        cache = utils.PolicyCache(tmp_path)
+        cache.initialize_watcher()
+
+        assert not cache.outdated
+
+        os.remove(file)
+
+        await asyncio.sleep(1)
+
+        assert cache.outdated
+
+    @pytest.mark.asyncio
+    async def test_13_no_change(self, tmp_path, mock_parser):
+        cache = utils.PolicyCache(tmp_path)
+        cache.initialize_watcher()
+
+        assert not cache.outdated
+
+        await asyncio.sleep(1)
+
+        assert not cache.outdated
+
+    @pytest.mark.asyncio
+    async def test_20_policy_updates(self, tmp_path, mock_parser):
+        cache = utils.PolicyCache(tmp_path)
+        cache.initialize_watcher()
+
+        mock_parser.assert_called_once_with(policy_path=tmp_path)
+
+        assert not cache.outdated
+
+        file = tmp_path / "test"
+        file.write_text("test")
+
+        await asyncio.sleep(1)
+
+        assert cache.outdated
+
+        cache.get_policy()
+
+        call = unittest.mock.call(policy_path=tmp_path)
+
+        assert mock_parser.mock_calls == [call, call]
+

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -20,12 +20,9 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
 import functools
-import os
-import shutil
 import socket
 import unittest.mock
-
-#import qubes.tests
+import asyncio
 
 from .. import QREXEC_CLIENT, QUBESD_INTERNAL_SOCK
 from .. import exc, utils
@@ -93,6 +90,11 @@ SYSTEM_INFO = {
 # a generic request helper
 _req = functools.partial(parser.Request, 'test.Service', '+argument',
     system_info=SYSTEM_INFO)
+
+# async mock
+class AsyncMock(unittest.mock.MagicMock):
+    async def __call__(self, *args, **kwargs):
+        return super(AsyncMock, self).__call__(*args, **kwargs)
 
 
 class TC_00_VMToken(unittest.TestCase):
@@ -1107,33 +1109,40 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.target, 'test-vm2')
 
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_120_execute(self, mock_subprocess, mock_qubesd_call):
+    def test_120_execute(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_120_execute(mock_subprocess, mock_qubesd_call))
+
+    async def _test_120_execute(self, mock_subprocess, mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm @anyvm allow',
             filepath='filename', lineno=12)
         request = _req('test-vm1', 'test-vm2')
         resolution = parser.AllowResolution(
             rule, request, user=None, target='test-vm2')
-        resolution.execute('some-ident')
+        await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls,
             [unittest.mock.call('test-vm2', 'admin.vm.Start')])
         self.assertEqual(mock_subprocess.mock_calls,
-            [unittest.mock.call([QREXEC_CLIENT, '-d', 'test-vm2',
+            [unittest.mock.call(QREXEC_CLIENT, '-d', 'test-vm2',
              '-c', 'some-ident',
-             'DEFAULT:QUBESRPC test.Service+argument test-vm1'])])
+             'DEFAULT:QUBESRPC test.Service+argument test-vm1'),
+             unittest.mock.call().communicate()])
 
     @unittest.expectedFailure
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_121_execute_dom0(self, mock_subprocess, mock_qubesd_call):
+    def test_121_execute_dom0(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_121_execute_dom0(mock_subprocess, mock_qubesd_call))
+
+    async def _test_121_execute_dom0(self, mock_subprocess, mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm dom0 allow',
             filepath='filename', lineno=12)
         request = _req('test-vm1', 'dom0')
         resolution = parser.AllowResolution(
             rule, request, user=None, target='dom0')
-        resolution.execute('some-ident')
+        await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls, [])
         self.assertEqual(mock_subprocess.mock_calls,
             [unittest.mock.call([QREXEC_CLIENT, '-d', 'dom0',
@@ -1141,24 +1150,31 @@ class TC_40_evaluate(unittest.TestCase):
              'QUBESRPC test.Service+argument test-vm1 name dom0'])])
 
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_121_execute_dom0_keyword(self, mock_subprocess, mock_qubesd_call):
+    def test_121_execute_dom0_keyword(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_121_execute_dom0_keyword(mock_subprocess, mock_qubesd_call))
+
+    async def _test_121_execute_dom0_keyword(self, mock_subprocess, mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm dom0 allow',
             filepath='filename', lineno=12)
         request = _req('test-vm1', '@adminvm')
         resolution = parser.AllowResolution(
             rule, request, user=None, target='@adminvm')
-        resolution.execute('some-ident')
+        await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls, [])
         self.assertEqual(mock_subprocess.mock_calls,
-            [unittest.mock.call([QREXEC_CLIENT, '-d', '@adminvm',
+            [unittest.mock.call(QREXEC_CLIENT, '-d', '@adminvm',
              '-c', 'some-ident',
-             'QUBESRPC test.Service+argument test-vm1 keyword adminvm'])])
+             'QUBESRPC test.Service+argument test-vm1 keyword adminvm'),
+             unittest.mock.call().communicate()])
 
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_122_execute_dispvm(self, mock_subprocess, mock_qubesd_call):
+    def test_122_execute_dispvm(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_122_execute_dispvm(mock_subprocess, mock_qubesd_call))
+
+    async def _test_122_execute_dispvm(self, mock_subprocess, mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm @dispvm:default-dvm allow',
             filepath='filename', lineno=12)
@@ -1169,19 +1185,23 @@ class TC_40_evaluate(unittest.TestCase):
         mock_qubesd_call.side_effect = (lambda target, call:
             b'dispvm-name' if call == 'admin.vm.CreateDisposable' else
             unittest.mock.DEFAULT)
-        resolution.execute('some-ident')
+        await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls,
             [unittest.mock.call('default-dvm', 'admin.vm.CreateDisposable'),
              unittest.mock.call('dispvm-name', 'admin.vm.Start'),
              unittest.mock.call('dispvm-name', 'admin.vm.Kill')])
         self.assertEqual(mock_subprocess.mock_calls,
-            [unittest.mock.call([QREXEC_CLIENT, '-d', 'dispvm-name',
+            [unittest.mock.call(QREXEC_CLIENT, '-d', 'dispvm-name',
              '-c', 'some-ident', '-W',
-             'DEFAULT:QUBESRPC test.Service+argument test-vm1'])])
+             'DEFAULT:QUBESRPC test.Service+argument test-vm1'),
+             unittest.mock.call().communicate()])
 
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_123_execute_already_running(self, mock_subprocess,
+    def test_123_execute_already_running(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_123_execute_already_running(mock_subprocess, mock_qubesd_call))
+
+    async def _test_123_execute_already_running(self, mock_subprocess,
             mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm @anyvm allow',
@@ -1191,17 +1211,21 @@ class TC_40_evaluate(unittest.TestCase):
             rule, request, user=None, target='test-vm2')
         mock_qubesd_call.side_effect = \
             exc.QubesMgmtException('QubesVMNotHaltedError')
-        resolution.execute('some-ident')
+        await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls,
             [unittest.mock.call('test-vm2', 'admin.vm.Start')])
         self.assertEqual(mock_subprocess.mock_calls,
-            [unittest.mock.call([QREXEC_CLIENT, '-d', 'test-vm2',
+            [unittest.mock.call(QREXEC_CLIENT, '-d', 'test-vm2',
              '-c', 'some-ident',
-             'DEFAULT:QUBESRPC test.Service+argument test-vm1'])])
+             'DEFAULT:QUBESRPC test.Service+argument test-vm1'),
+             unittest.mock.call().communicate()])
 
     @unittest.mock.patch('qrexec.utils.qubesd_call')
-    @unittest.mock.patch('subprocess.call')
-    def test_124_execute_startup_error(self, mock_subprocess,
+    def test_124_execute_startup_error(self, mock_qubesd_call):
+        with unittest.mock.patch('asyncio.create_subprocess_exec', new=AsyncMock()) as mock_subprocess:
+            asyncio.run(self._test_124_execute_startup_error(mock_subprocess, mock_qubesd_call))
+
+    async def _test_124_execute_startup_error(self, mock_subprocess,
             mock_qubesd_call):
         rule = parser.Rule.from_line(None,
             '* * @anyvm @anyvm allow',
@@ -1213,7 +1237,7 @@ class TC_40_evaluate(unittest.TestCase):
         mock_qubesd_call.side_effect = \
             exc.QubesMgmtException('QubesVMError')
         with self.assertRaises(exc.QubesMgmtException):
-            resolution.execute('some-ident')
+            await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls,
             [unittest.mock.call('test-vm2', 'admin.vm.Start')])
         self.assertEqual(mock_subprocess.mock_calls, [])

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -1,0 +1,178 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2019 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+
+import asyncio
+from contextlib import suppress
+
+import pytest
+from unittest.mock import Mock
+import functools
+
+import unittest
+import unittest.mock
+
+from ..tools import qrexec_policy_daemon
+
+class TestPolicyDaemon:
+    @pytest.fixture
+    def mock_request(self, monkeypatch):
+        mock_request = Mock()
+        monkeypatch.setattr('qrexec.tools.qrexec_policy_daemon.handle_request',
+                            mock_request)
+        return mock_request
+
+    @pytest.fixture
+    async def async_server(self, tmp_path, request):
+        log = unittest.mock.Mock()
+        server = await asyncio.start_unix_server(
+            functools.partial(qrexec_policy_daemon.handle_client_connection,
+                              log, "path"),
+            path=str(tmp_path / "socket.d"))
+
+        yield server
+
+        server.close()
+
+    async def send_data(self, server, path, data):
+        reader, writer = await asyncio.open_unix_connection(
+            str(path / "socket.d"))
+        writer.write(data)
+        await writer.drain()
+
+        await reader.read()
+
+        writer.close()
+
+        server.close()
+
+        await server.wait_closed()
+
+
+    @pytest.mark.asyncio
+    async def test_simple_request(self, mock_request, async_server, tmp_path):
+
+        data = b'domain_id=a\n' \
+               b'source=b\n' \
+               b'intended_target=c\n' \
+               b'service_and_arg=d\n' \
+               b'process_ident=1 9\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_called_once_with(
+            domain_id='a', source='b', intended_target='c',
+            service_and_arg='d', process_ident='1 9', log=unittest.mock.ANY,
+            path="path")
+
+    @pytest.mark.asyncio
+    async def test_complex_request(self, mock_request, async_server, tmp_path):
+
+        data = b'domain_id=a\n' \
+               b'source=b\n' \
+               b'intended_target=c\n' \
+               b'service_and_arg=d\n' \
+               b'process_ident=9\n' \
+               b'assume_yes_for_ask=yes\n' \
+               b'just_evaluate=yes\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_called_once_with(
+            domain_id='a', source='b', intended_target='c',
+            service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
+            assume_yes_for_ask=True, just_evaluate=True, path="path")
+
+    @pytest.mark.asyncio
+    async def test_complex_request2(self, mock_request, async_server, tmp_path):
+
+        data = b'domain_id=a\n' \
+               b'source=b\n' \
+               b'intended_target=c\n' \
+               b'service_and_arg=d\n' \
+               b'process_ident=9\n' \
+               b'assume_yes_for_ask=no\n' \
+               b'just_evaluate=no\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_called_once_with(
+            domain_id='a', source='b', intended_target='c',
+            service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
+            assume_yes_for_ask=False, just_evaluate=False, path="path")
+
+    @pytest.mark.asyncio
+    async def test_unfinished_request(
+            self, mock_request, async_server, tmp_path):
+
+        data = b'unfinished'
+
+        task = self.send_data(async_server, tmp_path, data)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(task, timeout=2)
+
+        for task in asyncio.Task.all_tasks():
+            task.cancel()
+
+        with suppress(asyncio.CancelledError):
+            await asyncio.sleep(1)
+
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_too_short_request(
+            self, mock_request, async_server, tmp_path):
+
+        data = b'domain_id=None\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_arg(self, mock_request, async_server, tmp_path):
+
+        data = b'domain_id=a\n' \
+               b'source=b\n' \
+               b'intended_target=c\n' \
+               b'service_and_arg=d\n' \
+               b'process_ident=9\n' \
+               b'assume_yes_for_ask=no\n' \
+               b'just_evaluate=no\n' \
+               b'domain_id=a\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_wrong_arg(self, mock_request, async_server, tmp_path):
+
+        data = b'domains_id=a\n' \
+               b'source=b\n' \
+               b'intended_target=c\n' \
+               b'service_and_arg=d\n' \
+               b'process_ident=9\n' \
+               b'assume_yes_for_ask=no\n' \
+               b'just_evaluate=no\n\n'
+
+        await self.send_data(async_server, tmp_path, data)
+
+        mock_request.assert_not_called()

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -83,7 +83,7 @@ class TestPolicyDaemon:
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='1 9', log=unittest.mock.ANY,
             policy_cache=unittest.mock.ANY,
-            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            allow_resolution_type=qrexec_policy_daemon.DaemonAllowResolution,
             origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
@@ -104,7 +104,7 @@ class TestPolicyDaemon:
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
             assume_yes_for_ask=True, just_evaluate=True,
             policy_cache=unittest.mock.ANY,
-            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            allow_resolution_type=qrexec_policy_daemon.DaemonAllowResolution,
             origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
@@ -125,7 +125,7 @@ class TestPolicyDaemon:
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
             assume_yes_for_ask=False, just_evaluate=False,
             policy_cache=unittest.mock.ANY,
-            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            allow_resolution_type=qrexec_policy_daemon.DaemonAllowResolution,
             origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
@@ -176,7 +176,7 @@ class TestPolicyDaemon:
     @pytest.mark.asyncio
     async def test_wrong_arg(self, mock_request, async_server, tmp_path):
 
-        data = b'domains_id=a\n' \
+        data = b'tremendous_domain_id=a\n' \
                b'source=b\n' \
                b'intended_target=c\n' \
                b'service_and_arg=d\n' \

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -30,6 +30,7 @@ import unittest
 import unittest.mock
 
 from ..tools import qrexec_policy_daemon
+from qrexec.policy.utils import PolicyCache
 
 class TestPolicyDaemon:
     @pytest.fixture
@@ -42,9 +43,10 @@ class TestPolicyDaemon:
     @pytest.fixture
     async def async_server(self, tmp_path, request):
         log = unittest.mock.Mock()
+
         server = await asyncio.start_unix_server(
             functools.partial(qrexec_policy_daemon.handle_client_connection,
-                              log, "path"),
+                              log, Mock()),
             path=str(tmp_path / "socket.d"))
 
         yield server
@@ -80,7 +82,7 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='1 9', log=unittest.mock.ANY,
-            path="path",
+            policy_cache=unittest.mock.ANY,
             allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
             origin_writer=unittest.mock.ANY)
 
@@ -100,7 +102,8 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
-            assume_yes_for_ask=True, just_evaluate=True, path="path",
+            assume_yes_for_ask=True, just_evaluate=True,
+            policy_cache=unittest.mock.ANY,
             allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
             origin_writer=unittest.mock.ANY)
 
@@ -120,7 +123,8 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
-            assume_yes_for_ask=False, just_evaluate=False, path="path",
+            assume_yes_for_ask=False, just_evaluate=False,
+            policy_cache=unittest.mock.ANY,
             allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
             origin_writer=unittest.mock.ANY)
 

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -22,6 +22,7 @@ import asyncio
 from contextlib import suppress
 
 import pytest
+import asynctest
 from unittest.mock import Mock
 import functools
 
@@ -33,7 +34,7 @@ from ..tools import qrexec_policy_daemon
 class TestPolicyDaemon:
     @pytest.fixture
     def mock_request(self, monkeypatch):
-        mock_request = Mock()
+        mock_request = asynctest.CoroutineMock()
         monkeypatch.setattr('qrexec.tools.qrexec_policy_daemon.handle_request',
                             mock_request)
         return mock_request
@@ -79,7 +80,9 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='1 9', log=unittest.mock.ANY,
-            path="path")
+            path="path",
+            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
     async def test_complex_request(self, mock_request, async_server, tmp_path):
@@ -97,7 +100,9 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
-            assume_yes_for_ask=True, just_evaluate=True, path="path")
+            assume_yes_for_ask=True, just_evaluate=True, path="path",
+            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
     async def test_complex_request2(self, mock_request, async_server, tmp_path):
@@ -115,7 +120,9 @@ class TestPolicyDaemon:
         mock_request.assert_called_once_with(
             domain_id='a', source='b', intended_target='c',
             service_and_arg='d', process_ident='9', log=unittest.mock.ANY,
-            assume_yes_for_ask=False, just_evaluate=False, path="path")
+            assume_yes_for_ask=False, just_evaluate=False, path="path",
+            allow_resolution_type=qrexec_policy_daemon.DaemonResolution,
+            origin_writer=unittest.mock.ANY)
 
     @pytest.mark.asyncio
     async def test_unfinished_request(
@@ -128,7 +135,7 @@ class TestPolicyDaemon:
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(task, timeout=2)
 
-        for task in asyncio.Task.all_tasks():
+        for task in asyncio.all_tasks():
             task.cancel()
 
         with suppress(asyncio.CancelledError):

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -30,7 +30,7 @@ import unittest
 import unittest.mock
 
 from ..tools import qrexec_policy_daemon
-from qrexec.policy.utils import PolicyCache
+
 
 class TestPolicyDaemon:
     @pytest.fixture

--- a/qrexec/tools/qrexec_policy_daemon.py
+++ b/qrexec/tools/qrexec_policy_daemon.py
@@ -48,7 +48,7 @@ ALLOWED_REQUEST_ARGUMENTS = REQUIRED_REQUEST_ARGUMENTS + \
                             OPTIONAL_REQUEST_ARGUMENTS
 
 
-class DaemonResolution(AllowResolution):
+class DaemonAllowResolution(AllowResolution):
     async def execute(self, caller_ident):
 
         log_prefix = 'qrexec: {request.service}+{request.argument}: ' \
@@ -62,7 +62,7 @@ class DaemonResolution(AllowResolution):
             self.request.origin_writer.write(b"result=allow\n")
             await self.request.origin_writer.drain()
 
-        await super(DaemonResolution, self).execute(caller_ident)
+        await super(DaemonAllowResolution, self).execute(caller_ident)
 
 
 async def handle_client_connection(log, policy_cache,
@@ -108,7 +108,7 @@ async def handle_client_connection(log, policy_cache,
                 'error parsing policy request: required argument missing')
             return
 
-        resolution_handler = DaemonResolution
+        resolution_handler = DaemonAllowResolution
 
         result = await handle_request(**args, log=log,
                                       allow_resolution_type=resolution_handler,

--- a/qrexec/tools/qrexec_policy_daemon.py
+++ b/qrexec/tools/qrexec_policy_daemon.py
@@ -1,0 +1,124 @@
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2019 Marta Marczykowska-Górecka
+#                               <marmarta@invisiblethingslab.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, see <https://www.gnu.org/licenses/>.
+#
+
+import argparse
+import functools
+import pathlib
+import asyncio
+import logging
+
+from .. import POLICYPATH, POLICYSOCKET
+
+from .qrexec_policy_exec import handle_request
+
+argparser = argparse.ArgumentParser(description='Evaluate qrexec policy daemon')
+
+argparser.add_argument('--policy-path',
+    type=pathlib.Path, default=POLICYPATH,
+    help='Use alternative policy path')
+argparser.add_argument('--socket-path',
+    type=pathlib.Path, default=POLICYSOCKET,
+    help='Use alternative policy socket path')
+
+REQUIRED_REQUEST_ARGUMENTS = ('domain_id', 'source', 'intended_target',
+                              'service_and_arg', 'process_ident')
+
+OPTIONAL_REQUEST_ARGUMENTS = ('assume_yes_for_ask', 'just_evaluate')
+
+ALLOWED_REQUEST_ARGUMENTS = REQUIRED_REQUEST_ARGUMENTS + \
+                            OPTIONAL_REQUEST_ARGUMENTS
+
+
+async def handle_client_connection(log, policy_path, reader, writer):
+
+    args = {}
+
+    try:
+        while True:
+            line = await reader.readline()
+            line = line.decode('ascii').rstrip('\n')
+
+            if not line:
+                break
+
+            argument, value = line.split('=', 1)
+            if argument in args:
+                log.error(
+                    'error parsing policy request: '
+                    'duplicate argument {}'.format(argument))
+                return
+            if argument not in ALLOWED_REQUEST_ARGUMENTS:
+                log.error(
+                    'error parsing policy request: unknown argument {}'.format(
+                        argument))
+                return
+
+            if argument in ('assume_yes_for_ask', 'just_evaluate'):
+                if value == 'yes':
+                    value = True
+                elif value == 'no':
+                    value = False
+                else:
+                    log.error(
+                        'error parsing policy request: invalid bool value '
+                        '{} for argument {}'.format(value, argument))
+                    return
+
+            args[argument] = value
+
+        if not all(arg in args for arg in REQUIRED_REQUEST_ARGUMENTS):
+            log.error(
+                'error parsing policy request: required argument missing')
+            return
+
+        result = handle_request(**args, log=log, path=policy_path)
+
+        writer.write(b"result=deny\n" if result else b"result=allow\n")
+
+        await writer.drain()
+
+    finally:
+        writer.close()
+
+
+async def start_serving(args=None):
+    args = argparser.parse_args(args)
+
+    log = logging.getLogger('policy')
+    log.setLevel(logging.INFO)
+    if not log.handlers:
+        handler = logging.handlers.SysLogHandler(address='/dev/log')
+        log.addHandler(handler)
+
+    server = await asyncio.start_unix_server(
+        functools.partial(handle_client_connection, log, args.policy_path),
+        path=args.socket_path)
+
+    await server.serve_forever()
+
+
+def main(args=None):
+    # pylint: disable=no-member
+    # due to travis' limitations we have to use python 3.5 in pylint
+    asyncio.run(start_serving(args))
+
+
+if __name__ == '__main__':
+    main()

--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -43,6 +43,7 @@ BuildRequires:  qubes-core-qrexec-devel
 Requires:   python3
 Requires:   qubes-core-dom0
 Requires:   qubes-core-qrexec
+Requires:   python3-inotify
 
 Conflicts:  qubes-core-dom0 < 4.0.9999
 Conflicts:  qubes-core-dom0-linux < 4.0.9999

--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -61,6 +61,12 @@ export BACKEND_VMM=@BACKEND_VMM@
 make all-dom0
 #make -C doc PYTHON=%{__python3} SPHINXBUILD=sphinx-build-%{python3_version} man
 
+%post
+%systemd_post qubes-qrexec-policy-daemon.service
+
+%preun
+%systemd_preun qubes-qrexec-policy-daemon.service
+
 %install
 make install-dom0 \
     DESTDIR=$RPM_BUILD_ROOT \
@@ -95,6 +101,8 @@ rm -f %{name}-%{version}
 %dir %{_sysconfdir}/qubes-rpc/policy/include
 
 %{_sysconfdir}/qubes-rpc/policy.RegisterArgument
+
+/lib/systemd/system/qubes-qrexec-policy-daemon.service
 
 %changelog
 @CHANGELOG@

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -122,6 +122,7 @@ rm -f %{name}-%{version}
 %{python3_sitelib}/qrexec/policy/api.py
 %{python3_sitelib}/qrexec/policy/parser.py
 %{python3_sitelib}/qrexec/policy/parser_compat.py
+%{python3_sitelib}/qrexec/policy/utils.py
 
 %dir %{python3_sitelib}/qrexec/tools
 %dir %{python3_sitelib}/qrexec/tools/__pycache__

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -97,6 +97,7 @@ rm -f %{name}-%{version}
 %{_bindir}/qrexec-policy-agent
 %{_bindir}/qrexec-policy-graph
 %{_bindir}/qrexec-policy-restore
+%{_bindir}/qrexec-policy-daemon
 %{_bindir}/qubes-policy
 %{_bindir}/qrexec-policy
 
@@ -129,6 +130,7 @@ rm -f %{name}-%{version}
 %{python3_sitelib}/qrexec/tools/qubes_policy.py
 %{python3_sitelib}/qrexec/tools/qrexec_policy_agent.py
 %{python3_sitelib}/qrexec/tools/qrexec_policy_exec.py
+%{python3_sitelib}/qrexec/tools/qrexec_policy_daemon.py
 %{python3_sitelib}/qrexec/tools/qrexec_policy_graph.py
 %{python3_sitelib}/qrexec/tools/qrexec_policy_restore.py
 
@@ -141,6 +143,7 @@ rm -f %{name}-%{version}
 %{python3_sitelib}/qrexec/tests/rpcconfirmation.py
 %{python3_sitelib}/qrexec/tests/policy_api.py
 %{python3_sitelib}/qrexec/tests/policy_parser.py
+%{python3_sitelib}/qrexec/tests/qrexec_policy_daemon.py
 
 %dir %{python3_sitelib}/qrexec/glade
 %{python3_sitelib}/qrexec/glade/PolicyCreateConfirmationWindow.glade

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -145,6 +145,7 @@ rm -f %{name}-%{version}
 %{python3_sitelib}/qrexec/tests/policy_api.py
 %{python3_sitelib}/qrexec/tests/policy_parser.py
 %{python3_sitelib}/qrexec/tests/qrexec_policy_daemon.py
+%{python3_sitelib}/qrexec/tests/policy_cache.py
 
 %dir %{python3_sitelib}/qrexec/glade
 %{python3_sitelib}/qrexec/glade/PolicyCreateConfirmationWindow.glade

--- a/systemd/qubes-qrexec-policy-daemon.service
+++ b/systemd/qubes-qrexec-policy-daemon.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Qubes remote exec policy daemon
+After=qubesd.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/qrexec-policy-daemon


### PR DESCRIPTION
Rewritten qrexec-daemon to use policy daemon instead of running
policy-exec separately for each call. If daemon fails, falls back
to old solution. Also contains some tests.

fixes QubesOS/qubes-issues#5125