### PR TITLE
qrexec-client-vm: add option to replace control characters on stdout/err

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -48,6 +48,28 @@ int stdout_msg_type = MSG_DATA_STDOUT;
 pid_t child_process_pid;
 int remote_process_status = 0;
 
+/* whether qrexec-client should replace problematic bytes with _ before printing the output;
+ * positive value will enable the feature
+ */
+int replace_chars_stdout = -1;
+int replace_chars_stderr = -1;
+
+void do_replace_chars(char *buf, int len) {
+    int i;
+    unsigned char c;
+
+    for (i = 0; i < len; i++) {
+        c = buf[i];
+        if ((c < '\040' || c > '\176') &&  /* not printable ASCII */
+            (c != '\t') &&                 /* not tab */
+            (c != '\n') &&                 /* not newline */
+            (c != '\r') &&                 /* not return */
+            (c != '\b') &&                 /* not backspace */
+            (c != '\a'))                   /* not bell */
+            buf[i] = '_';
+    }
+}
+
 static void sigchld_handler(int __attribute__((__unused__))x)
 {
     child_exited = 1;
@@ -271,6 +293,8 @@ int handle_remote_data(libvchan_t *data_vchan, int stdin_fd, int *status,
                     rc = 0;
                     goto out;
                 } else {
+                    if (replace_chars_stdout > 0)
+                        do_replace_chars(buf, hdr.len);
                     switch (write_stdin(stdin_fd, buf, hdr.len, stdin_buf)) {
                         case WRITE_STDIN_OK:
                             break;
@@ -294,6 +318,8 @@ int handle_remote_data(libvchan_t *data_vchan, int stdin_fd, int *status,
                 }
                 break;
             case MSG_DATA_STDERR:
+                if (replace_chars_stderr > 0)
+                    do_replace_chars(buf, hdr.len);
                 /* stderr of remote service, log locally */
                 if (!write_all(2, buf, hdr.len)) {
                     perror("write");

--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -32,6 +32,10 @@ void do_exec(char *cmd);
 /* call before fork() for service handling process (either end) */
 void prepare_child_env();
 
+// whether qrexec-client should replace problematic bytes with _ before printing the output
+extern int replace_chars_stdout;
+extern int replace_chars_stderr;
+
 pid_t handle_new_process(int type,
         int connect_domain, int connect_port,
         char *cmdline, int cmdline_len);

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -86,16 +86,30 @@ void convert_target_name_keyword(char *target)
             target[i] = '@';
 }
 
+enum {
+    opt_no_filter_stdout = 't'+128,
+    opt_no_filter_stderr = 'T'+128,
+};
+
 struct option longopts[] = {
     { "buffer-size", required_argument, 0,  'b' },
+    { "filter-escape-chars-stdout", no_argument, 0, 't'},
+    { "filter-escape-chars-stderr", no_argument, 0, 'T'},
+    { "no-filter-escape-chars-stdout", no_argument, 0, opt_no_filter_stdout},
+    { "no-filter-escape-chars-stderr", no_argument, 0, opt_no_filter_stderr},
     { NULL, 0, 0, 0},
 };
 
 _Noreturn void usage(const char *argv0) {
     fprintf(stderr,
-            "usage: %s [--buffer-size=BUFFER_SIZE] target_vmname program_ident [local_program [local program arguments]]\n",
+            "usage: %s [options] target_vmname program_ident [local_program [local program arguments]]\n",
             argv0);
-    fprintf(stderr, "BUFFER_SIZE is minimum vchan buffer size (default: 64k)\n");
+    fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  --buffer-size=BUFFER_SIZE - minimum vchan buffer size (default: 64k)\n");
+    fprintf(stderr, "  -t, --filter-escape-chars-stdout - filter non-ASCII and control characters on stdout (default if stdout is a terminal)\n");
+    fprintf(stderr, "  -T, --filter-escape-chars-stderr - filter non-ASCII and control characters on stderr (default if stderr is a terminal)\n");
+    fprintf(stderr, "  --no-filter-escape-chars-stdout - opposite to --filter-escape-chars-stdout\n");
+    fprintf(stderr, "  --no-filter-escape-chars-stderr - opposite to --filter-escape-chars-stderr\n");
     exit(2);
 }
 
@@ -116,12 +130,24 @@ int main(int argc, char **argv)
     int opt;
 
     while (1) {
-        opt = getopt_long(argc, argv, "+", longopts, NULL);
+        opt = getopt_long(argc, argv, "+tT", longopts, NULL);
         if (opt == -1)
             break;
         switch (opt) {
             case 'b':
                 buffer_size = atoi(optarg);
+                break;
+            case 't':
+                replace_chars_stdout = 1;
+                break;
+            case 'T':
+                replace_chars_stderr = 1;
+                break;
+            case opt_no_filter_stdout:
+                replace_chars_stdout = 0;
+                break;
+            case opt_no_filter_stderr:
+                replace_chars_stderr = 0;
                 break;
             case '?':
                 usage(argv[0]);
@@ -134,6 +160,13 @@ int main(int argc, char **argv)
     if (argc - optind > 2) {
         start_local_process = 1;
     }
+
+    if (!start_local_process) {
+        if (replace_chars_stdout == -1 && isatty(1))
+            replace_chars_stdout = 1;
+    }
+    if (replace_chars_stderr == -1 && isatty(2))
+        replace_chars_stderr = 1;
 
     service_name = argv[optind + 1];
 


### PR DESCRIPTION
And enable it by default when stdout/stderr is connected to terminal.

Fixes QubesOS/qubes-issues#5322