### PR TITLE
qrexec-client: ignore SIGPIPE

### DIFF
--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -742,6 +742,8 @@ int main(int argc, char **argv)
         usage(argv[0]);
     remote_cmdline = argv[optind];
 
+    signal(SIGPIPE, SIG_IGN);
+
     register_exec_func(&do_exec);
 
     if (just_exec + connect_existing + (local_cmdline != 0) > 1) {


### PR DESCRIPTION
This caused qrexec-client to be killed when the local process
exited (by design) before consuming all the input, for instance
when receiving too much data for the admin.vm.volume.Import call.