### PR TITLE
Separate GTK test classes from object under test

### DIFF
--- a/qrexec/tests/gtkhelpers.py
+++ b/qrexec/tests/gtkhelpers.py
@@ -18,6 +18,8 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
 
+# pylint:disable=protected-access
+
 import time
 import unittest
 import os
@@ -82,60 +84,59 @@ class GtkTestCase(unittest.TestCase):
 
 
 @unittest.skipUnless('DISPLAY' in os.environ, 'no DISPLAY variable')
-class VMListModelerTest(VMListModeler, unittest.TestCase):
-    def __init__(self, *args, **kwargs):
-        unittest.TestCase.__init__(self, *args, **kwargs)
-        VMListModeler.__init__(self, mock_domains_info)
+class VMListModelerTest(unittest.TestCase):
+    def setUp(self):
+        self.modeler = VMListModeler(mock_domains_info)
 
     def test_entries_gets_loaded(self):
-        self.assertIsNotNone(self._entries)
+        self.assertIsNotNone(self.modeler._entries)
 
     def test_valid_qube_name(self):
-        self.apply_model(Gtk.ComboBox(), list(mock_domains_info.keys()))
+        self.modeler.apply_model(Gtk.ComboBox(), list(mock_domains_info.keys()))
 
         for name in ["test-red1", "test-red2", "test-red3",
                      "test-target", "Disposable VM (test-disp6)"]:
 
             mock = MockComboEntry(name)
             self.assertEqual(name,
-                self._get_valid_qube_name(mock, mock, mock_whitelist))
+                self.modeler._get_valid_qube_name(mock, mock, mock_whitelist))
             self.assertEqual(name,
-                self._get_valid_qube_name(None, mock, mock_whitelist))
+                self.modeler._get_valid_qube_name(None, mock, mock_whitelist))
             self.assertEqual(name,
-                self._get_valid_qube_name(mock, None, mock_whitelist))
+                self.modeler._get_valid_qube_name(mock, None, mock_whitelist))
             self.assertIsNone(
-                self._get_valid_qube_name(None, None, mock_whitelist))
+                self.modeler._get_valid_qube_name(None, None, mock_whitelist))
 
     def test_valid_qube_name_whitelist(self):
         list_exc = ["@dispvm:test-disp6", "test-red2"]
 
         whitelist = [name for name in mock_whitelist if name not in list_exc]
-        self.apply_model(Gtk.ComboBox(), whitelist)
+        self.modeler.apply_model(Gtk.ComboBox(), whitelist)
 
         for name in list_exc:
             mock = MockComboEntry(name)
-            self.assertIsNone(self._get_valid_qube_name(mock, mock, whitelist))
-            self.assertIsNone(self._get_valid_qube_name(None, mock, whitelist))
-            self.assertIsNone(self._get_valid_qube_name(mock, None, whitelist))
+            self.assertIsNone(self.modeler._get_valid_qube_name(mock, mock, whitelist))
+            self.assertIsNone(self.modeler._get_valid_qube_name(None, mock, whitelist))
+            self.assertIsNone(self.modeler._get_valid_qube_name(mock, None, whitelist))
 
     def test_invalid_qube_name(self):
-        self.apply_model(Gtk.ComboBox(), mock_whitelist)
+        self.modeler.apply_model(Gtk.ComboBox(), mock_whitelist)
 
         for name in ["test-nonexistant", None, "", 1]:
 
             mock = MockComboEntry(name)
             self.assertIsNone(
-                self._get_valid_qube_name(mock, mock, mock_whitelist))
+                self.modeler._get_valid_qube_name(mock, mock, mock_whitelist))
             self.assertIsNone(
-                self._get_valid_qube_name(None, mock, mock_whitelist))
+                self.modeler._get_valid_qube_name(None, mock, mock_whitelist))
             self.assertIsNone(
-                self._get_valid_qube_name(mock, None, mock_whitelist))
+                self.modeler._get_valid_qube_name(mock, None, mock_whitelist))
 
     def test_apply_model(self):
         new_object = Gtk.ComboBox()
         self.assertIsNone(new_object.get_model())
 
-        self.apply_model(new_object, mock_whitelist)
+        self.modeler.apply_model(new_object, mock_whitelist)
 
         self.assertIsNotNone(new_object.get_model())
 
@@ -144,7 +145,7 @@ class VMListModelerTest(VMListModeler, unittest.TestCase):
 
         self.assertIsNone(new_object.get_model())
 
-        self.apply_model(new_object, [])
+        self.modeler.apply_model(new_object, [])
 
         self.assertIsNotNone(new_object.get_model())
 
@@ -154,20 +155,20 @@ class VMListModelerTest(VMListModeler, unittest.TestCase):
 
         for invalid_type in invalid_types:
             with self.assertRaises(TypeError):
-                self.apply_model(invalid_type, [])
+                self.modeler.apply_model(invalid_type, [])
 
     def test_apply_model_whitelist(self):
         combo = Gtk.ComboBox()
 
-        self.apply_model(combo, list(mock_domains_info.keys()))
+        self.modeler.apply_model(combo, list(mock_domains_info.keys()))
         self.assertEqual(7, len(combo.get_model()))
 
-        names = [entry['api_name'] for entry in self._entries.values()]
+        names = [entry['api_name'] for entry in self.modeler._entries.values()]
 
-        self.apply_model(combo, [names[0]])
+        self.modeler.apply_model(combo, [names[0]])
         self.assertEqual(1, len(combo.get_model()))
 
-        self.apply_model(combo, [names[0], names[1]])
+        self.modeler.apply_model(combo, [names[0], names[1]])
         self.assertEqual(2, len(combo.get_model()))
 
     def test_apply_icon(self):
@@ -176,7 +177,7 @@ class VMListModelerTest(VMListModeler, unittest.TestCase):
         self.assertIsNone(
                 new_object.get_icon_pixbuf(Gtk.EntryIconPosition.PRIMARY))
 
-        self.apply_icon(new_object, "Disposable VM (test-disp6)")
+        self.modeler.apply_icon(new_object, "Disposable VM (test-disp6)")
 
         self.assertIsNotNone(
                 new_object.get_icon_pixbuf(Gtk.EntryIconPosition.PRIMARY))
@@ -186,222 +187,222 @@ class VMListModelerTest(VMListModeler, unittest.TestCase):
 
         for invalid_type in invalid_types:
             with self.assertRaises(TypeError):
-                self.apply_icon(invalid_type, "test-disp6")
+                self.modeler.apply_icon(invalid_type, "test-disp6")
 
     def test_apply_icon_only_existing(self):
         new_object = Gtk.Entry()
 
         for name in ["test-red1", "test-red2", "test-red3",
                      "test-target", "Disposable VM (test-disp6)"]:
-            self.apply_icon(new_object, name)
+            self.modeler.apply_icon(new_object, name)
 
         for name in ["test-nonexistant", None, "", 1]:
             with self.assertRaises(ValueError):
-                self.apply_icon(new_object, name)
+                self.modeler.apply_icon(new_object, name)
 
 
-class GtkOneTimerHelperTest(GtkOneTimerHelper, GtkTestCase):
-    def __init__(self, *args, **kwargs):
-        GtkTestCase.__init__(self, *args, **kwargs)
-
-        self._test_time = 0.1
-
-        GtkOneTimerHelper.__init__(self, self._test_time)
+class GtkOneTimerHelperMock(GtkOneTimerHelper):
+    def __init__(self, t):
+        super().__init__(t)
         self._run_timers = []
 
     def _timer_run(self, timer_id):
         self._run_timers.append(timer_id)
 
+
+class GtkOneTimerHelperTest(GtkTestCase):
+    def setUp(self):
+        self._test_time = 0.1
+        self.helper = GtkOneTimerHelperMock(self._test_time)
+
     def test_nothing_runs_automatically(self):
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([], self._run_timers)
-        self.assertEqual(0, self._current_timer_id)
-        self.assertFalse(self._timer_has_completed())
+        self.assertEqual([], self.helper._run_timers)
+        self.assertEqual(0, self.helper._current_timer_id)
+        self.assertFalse(self.helper._timer_has_completed())
 
     def test_schedule_one_task(self):
-        self._timer_schedule()
+        self.helper._timer_schedule()
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1], self._run_timers)
-        self.assertEqual(1, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([1], self.helper._run_timers)
+        self.assertEqual(1, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
     def test_invalidate_completed(self):
-        self._timer_schedule()
+        self.helper._timer_schedule()
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1], self._run_timers)
-        self.assertEqual(1, self._current_timer_id)
+        self.assertEqual([1], self.helper._run_timers)
+        self.assertEqual(1, self.helper._current_timer_id)
 
-        self.assertTrue(self._timer_has_completed())
-        self._invalidate_timer_completed()
-        self.assertFalse(self._timer_has_completed())
+        self.assertTrue(self.helper._timer_has_completed())
+        self.helper._invalidate_timer_completed()
+        self.assertFalse(self.helper._timer_has_completed())
 
     def test_schedule_and_cancel_one_task(self):
-        self._timer_schedule()
-        self._invalidate_current_timer()
+        self.helper._timer_schedule()
+        self.helper._invalidate_current_timer()
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([], self._run_timers)
-        self.assertEqual(2, self._current_timer_id)
-        self.assertFalse(self._timer_has_completed())
+        self.assertEqual([], self.helper._run_timers)
+        self.assertEqual(2, self.helper._current_timer_id)
+        self.assertFalse(self.helper._timer_has_completed())
 
     def test_two_tasks(self):
-        self._timer_schedule()
+        self.helper._timer_schedule()
         self.flush_gtk_events(self._test_time/4)
-        self._timer_schedule()
+        self.helper._timer_schedule()
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([2], self._run_timers)
-        self.assertEqual(2, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([2], self.helper._run_timers)
+        self.assertEqual(2, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
     def test_more_tasks(self):
         num = 0
         for num in range(1, 10):
-            self._timer_schedule()
+            self.helper._timer_schedule()
             self.flush_gtk_events(self._test_time/4)
         self.flush_gtk_events(self._test_time*1.75)
-        self.assertEqual([num], self._run_timers)
-        self.assertEqual(num, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([num], self.helper._run_timers)
+        self.assertEqual(num, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
     def test_more_tasks_cancel(self):
         num = 0
         for num in range(1, 10):
-            self._timer_schedule()
+            self.helper._timer_schedule()
             self.flush_gtk_events(self._test_time/4)
-        self._invalidate_current_timer()
+        self.helper._invalidate_current_timer()
         self.flush_gtk_events(int(self._test_time*1.75))
-        self.assertEqual([], self._run_timers)
-        self.assertEqual(num+1, self._current_timer_id)
-        self.assertFalse(self._timer_has_completed())
+        self.assertEqual([], self.helper._run_timers)
+        self.assertEqual(num+1, self.helper._current_timer_id)
+        self.assertFalse(self.helper._timer_has_completed())
 
     def test_subsequent_tasks(self):
-        self._timer_schedule()  # 1
+        self.helper._timer_schedule()  # 1
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1], self._run_timers)
-        self.assertEqual(1, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([1], self.helper._run_timers)
+        self.assertEqual(1, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
-        self._timer_schedule()  # 2
+        self.helper._timer_schedule()  # 2
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1, 2], self._run_timers)
-        self.assertEqual(2, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([1, 2], self.helper._run_timers)
+        self.assertEqual(2, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
-        self._invalidate_timer_completed()
-        self._timer_schedule()  # 3
-        self._invalidate_current_timer()  # 4
+        self.helper._invalidate_timer_completed()
+        self.helper._timer_schedule()  # 3
+        self.helper._invalidate_current_timer()  # 4
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1, 2], self._run_timers)
-        self.assertEqual(4, self._current_timer_id)
-        self.assertFalse(self._timer_has_completed())
+        self.assertEqual([1, 2], self.helper._run_timers)
+        self.assertEqual(4, self.helper._current_timer_id)
+        self.assertFalse(self.helper._timer_has_completed())
 
-        self._timer_schedule()  # 5
+        self.helper._timer_schedule()  # 5
         self.flush_gtk_events(self._test_time*2)
-        self.assertEqual([1, 2, 5], self._run_timers)
-        self.assertEqual(5, self._current_timer_id)
-        self.assertTrue(self._timer_has_completed())
+        self.assertEqual([1, 2, 5], self.helper._run_timers)
+        self.assertEqual(5, self.helper._current_timer_id)
+        self.assertTrue(self.helper._timer_has_completed())
 
 
 class FocusStealingHelperMock(FocusStealingHelper):
     def simulate_focus(self):
         self._window_changed_focus(True)
 
+    def _simulate_focus(self, focused):
+        self._window_changed_focus(focused)
+
 
 @unittest.skipUnless('DISPLAY' in os.environ, 'no DISPLAY variable')
-class FocusStealingHelperTest(FocusStealingHelperMock, GtkTestCase):
-    def __init__(self, *args, **kwargs):
-        GtkTestCase.__init__(self, *args, **kwargs)
-
+class FocusStealingHelperTest(GtkTestCase):
+    def setUp(self):
         self._test_time = 0.1
         self._test_button = Gtk.Button()
         self._test_window = Gtk.Window()
 
-        FocusStealingHelperMock.__init__(self, self._test_window,
-            self._test_button, self._test_time)
+        self.helper = FocusStealingHelperMock(
+            self._test_window, self._test_button, self._test_time)
 
     def test_nothing_runs_automatically(self):
-        self.assertFalse(self.can_perform_action())
+        self.assertFalse(self.helper.can_perform_action())
         self.flush_gtk_events(self._test_time*2)
-        self.assertFalse(self.can_perform_action())
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
     def test_nothing_runs_automatically_with_request(self):
-        self.request_sensitivity(True)
-        self.assertFalse(self.can_perform_action())
+        self.helper.request_sensitivity(True)
+        self.assertFalse(self.helper.can_perform_action())
         self.flush_gtk_events(self._test_time*2)
-        self.assertFalse(self.can_perform_action())
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
-    def _simulate_focus(self, focused):
-        self._window_changed_focus(focused)
-
     def test_focus_with_request(self):
-        self.request_sensitivity(True)
-        self._simulate_focus(True)
+        self.helper.request_sensitivity(True)
+        self.helper._simulate_focus(True)
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertTrue(self._test_button.get_sensitive())
 
     def test_focus_with_late_request(self):
-        self._simulate_focus(True)
+        self.helper._simulate_focus(True)
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
-        self.request_sensitivity(True)
+        self.helper.request_sensitivity(True)
         self.assertTrue(self._test_button.get_sensitive())
 
     def test_immediate_defocus(self):
-        self.request_sensitivity(True)
-        self._simulate_focus(True)
-        self._simulate_focus(False)
+        self.helper.request_sensitivity(True)
+        self.helper._simulate_focus(True)
+        self.helper._simulate_focus(False)
         self.flush_gtk_events(self._test_time*2)
-        self.assertFalse(self.can_perform_action())
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
     def test_focus_then_unfocus(self):
-        self.request_sensitivity(True)
-        self._simulate_focus(True)
+        self.helper.request_sensitivity(True)
+        self.helper._simulate_focus(True)
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertTrue(self._test_button.get_sensitive())
 
-        self._simulate_focus(False)
-        self.assertFalse(self.can_perform_action())
+        self.helper._simulate_focus(False)
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
     def test_focus_cycle(self):
-        self.request_sensitivity(True)
+        self.helper.request_sensitivity(True)
 
-        self._simulate_focus(True)
+        self.helper._simulate_focus(True)
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertTrue(self._test_button.get_sensitive())
 
-        self._simulate_focus(False)
-        self.assertFalse(self.can_perform_action())
+        self.helper._simulate_focus(False)
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
-        self._simulate_focus(True)
-        self.assertFalse(self.can_perform_action())
+        self.helper._simulate_focus(True)
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertTrue(self._test_button.get_sensitive())
 
-        self.request_sensitivity(False)
-        self.assertTrue(self.can_perform_action())
+        self.helper.request_sensitivity(False)
+        self.assertTrue(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
-        self._simulate_focus(False)
-        self.assertFalse(self.can_perform_action())
+        self.helper._simulate_focus(False)
+        self.assertFalse(self.helper.can_perform_action())
 
-        self._simulate_focus(True)
-        self.assertFalse(self.can_perform_action())
+        self.helper._simulate_focus(True)
+        self.assertFalse(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
         self.flush_gtk_events(self._test_time*2)
-        self.assertTrue(self.can_perform_action())
+        self.assertTrue(self.helper.can_perform_action())
         self.assertFalse(self._test_button.get_sensitive())
 
 if __name__ == '__main__':

--- a/qrexec/tests/gtkhelpers.py
+++ b/qrexec/tests/gtkhelpers.py
@@ -55,6 +55,7 @@ class MockComboEntry:
         return self._text
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class GtkTestCase(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
@@ -83,7 +84,7 @@ class GtkTestCase(unittest.TestCase):
         return iterations, time_length
 
 
-@unittest.skipUnless('DISPLAY' in os.environ, 'no DISPLAY variable')
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class VMListModelerTest(unittest.TestCase):
     def setUp(self):
         self.modeler = VMListModeler(mock_domains_info)
@@ -210,6 +211,7 @@ class GtkOneTimerHelperMock(GtkOneTimerHelper):
         self._run_timers.append(timer_id)
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class GtkOneTimerHelperTest(GtkTestCase):
     def setUp(self):
         self._test_time = 0.1
@@ -312,7 +314,7 @@ class FocusStealingHelperMock(FocusStealingHelper):
         self._window_changed_focus(focused)
 
 
-@unittest.skipUnless('DISPLAY' in os.environ, 'no DISPLAY variable')
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class FocusStealingHelperTest(GtkTestCase):
     def setUp(self):
         self._test_time = 0.1

--- a/qrexec/tests/rpcconfirmation.py
+++ b/qrexec/tests/rpcconfirmation.py
@@ -22,6 +22,7 @@
 
 import sys
 import unittest
+import os
 
 from qrexec.tests.gtkhelpers import GtkTestCase, FocusStealingHelperMock
 from qrexec.tests.gtkhelpers import mock_domains_info, mock_whitelist
@@ -89,6 +90,7 @@ class MockRPCConfirmationWindow(RPCConfirmationWindow):
         return domains
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class RPCConfirmationWindowTestBase(GtkTestCase):
     def __init__(self, test_method, source_name="test-source",
                  rpc_operation="test.Operation", whitelist=mock_whitelist,
@@ -240,6 +242,7 @@ class RPCConfirmationWindowTestBase(GtkTestCase):
             self.assertFalse(self.window._focus_helper.can_perform_action())
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class RPCConfirmationWindowTestWithTarget(RPCConfirmationWindowTestBase):
     def __init__(self, test_method):
         RPCConfirmationWindowTestBase.__init__(self, test_method,
@@ -268,6 +271,7 @@ class RPCConfirmationWindowTestWithTarget(RPCConfirmationWindowTestBase):
         self.assertIsNotNone(self.window._target_name)
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class RPCConfirmationWindowTestWithDispVMTarget(RPCConfirmationWindowTestBase):
     def __init__(self, test_method):
         RPCConfirmationWindowTestBase.__init__(self, test_method,
@@ -292,6 +296,7 @@ class RPCConfirmationWindowTestWithDispVMTarget(RPCConfirmationWindowTestBase):
             self.assertFalse(self.window._focus_helper.can_perform_action())
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class RPCConfirmationWindowTestWithTargetInvalid(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)
@@ -311,6 +316,7 @@ class RPCConfirmationWindowTestWithTargetInvalid(unittest.TestCase):
         self.assertEquals(expect, rpcWindow.is_error_visible())
 
 
+@unittest.skipUnless(os.environ.get('DISPLAY'), 'no DISPLAY variable')
 class RPCConfirmationWindowTestWhitelist(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         unittest.TestCase.__init__(self, *args, **kwargs)


### PR DESCRIPTION
The tests for GTK objects used multiple inheritance to combine
TestCase class and the class being tested. This made the code more
confusing, but also caused the GTK objects to be initialized when
loading (not executing) the test, which can cause a segfault if
X is not available.

I rewrote the tests to use composition instead of inheritance,
creating an object (self.window, etc.) in the setUp method.