### PR TITLE
 daemon, agent: ensure proper shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ pkgs/
 *.so.[0-9]
 *.so
 *.o.dep
+*.gcno
+*.gcda
+*.gcov
 *~
 \#*#

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,11 @@ jobs:
        - pip install --quiet 'coverage<5.0'
        - docker build -t qrexec-test ci
       env: DOCKER_RUN="docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -v /tmp/.X11-unix:/tmp/.X11-unix -w $TRAVIS_BUILD_DIR -e DISPLAY=$DISPLAY -- qrexec-test"
-      script: $DOCKER_RUN ./run-tests
+      script:
+       - $DOCKER_RUN ./run-tests
+       # use gcov from within the container
+       - $DOCKER_RUN find . -type f -name '*.gcno'  -execdir gcov -pb  {} +
+       - find . -type f -name '*.gcno'  -exec rm  {} +
 #    - python: '3.7'
 #      script: python -m coverage run -m unittest discover -s qrexec/tests -t . -p '*.py' -v
     - stage: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ jobs:
       script: pylint qrexec
     - install:
        - pip install --quiet codecov
+       - pip install --quiet 'coverage<5.0'
        - docker build -t qrexec-test ci
       env: DOCKER_RUN="docker run -v $TRAVIS_BUILD_DIR:$TRAVIS_BUILD_DIR -v /tmp/.X11-unix:/tmp/.X11-unix -w $TRAVIS_BUILD_DIR -e DISPLAY=$DISPLAY -- qrexec-test"
       script: $DOCKER_RUN ./run-tests

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -1055,4 +1055,6 @@ int main(int argc, char **argv)
 
         handle_terminated_fork_client(&rdset);
     }
+
+    libvchan_close(ctrl_vchan);
 }

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM fedora:31
 
 RUN dnf install -y python3-pip python3-gobject gtk3 python3-pytest \
-    python3-coverage python3-devel pam-devel pandoc gcc git make
+    python3-coverage python3-devel pam-devel pandoc gcc git make findutils
 
 RUN git clone https://github.com/QubesOS/qubes-core-vchan-socket ~/qubes-core-vchan-socket
 RUN make -C ~/qubes-core-vchan-socket all

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1073,7 +1073,9 @@ int main(int argc, char **argv)
         if (child_exited)
             reap_children();
         ret = select(max+1, &read_fdset, &write_fdset, NULL, &tv);
-        if (ret < 0 && errno != EINTR) {
+        if (ret < 0) {
+            if (errno == EINTR)
+                continue;
             perror("select");
             return 1;
         }

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -99,6 +99,7 @@ const char *policy_program = QREXEC_POLICY_PROGRAM;
 #endif
 
 volatile int children_count;
+int child_exited;
 
 libvchan_t *vchan;
 int protocol_version;
@@ -630,8 +631,6 @@ static void handle_message_from_client(int fd)
  * flag in appropriate moment.
  */
 
-int child_exited;
-
 static void sigchld_handler(int UNUSED(x))
 {
     child_exited = 1;
@@ -1047,7 +1046,6 @@ int main(int argc, char **argv)
     init(remote_domain_id);
     sigemptyset(&chld_set);
     sigaddset(&chld_set, SIGCHLD);
-    signal(SIGCHLD, sigchld_handler);
     /*
      * The main event loop. Waits for one of the following events:
      * - message from client

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -55,6 +55,11 @@ exit 1
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
+        self.daemon = None
+
+    def tearDown(self):
+        self.stop_daemon()
+        super().tearDown()
 
     def start_daemon(self):
         policy_program_path = os.path.join(self.tempdir, 'qrexec-policy-exec')
@@ -80,7 +85,6 @@ exit 1
             cmd,
             env=env,
         )
-        self.addCleanup(self.stop_daemon)
 
     def stop_daemon(self):
         if self.daemon:

--- a/run-tests
+++ b/run-tests
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 if pkg-config vchan-socket; then
-    export CFLAGS=--coverage
+    export CFLAGS="--coverage -DCOVERAGE"
     export LDFLAGS=--coverage
     make -C libqrexec BACKEND_VMM=socket
     make -C agent BACKEND_VMM=socket

--- a/run-tests
+++ b/run-tests
@@ -1,6 +1,8 @@
 #!/bin/sh -e
 
 if pkg-config vchan-socket; then
+    export CFLAGS=--coverage
+    export LDFLAGS=--coverage
     make -C libqrexec BACKEND_VMM=socket
     make -C agent BACKEND_VMM=socket
     make -C daemon BACKEND_VMM=socket


### PR DESCRIPTION
On top of #22.

- The daemon might receive SIGTERM while reconnecting. There is no
  simple way of interrupting the reconnection, so just allow it to
  die.
- In the above case, dump coverage data (if running in tests) to
  ensure SIGTERM doesn't wipe it.
- Close vchan on exit: also important for tests (to flush remaning
  data to socket).