### PR TITLE
Clean up error logging

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -150,7 +150,7 @@ static int handle_just_exec(char *cmdline)
             do_exec(end_username, cmdline);
         default:;
     }
-    LOG(INFO, "executed (nowait) %s pid %d", cmdline, pid);
+    LOG(INFO, "executed (nowait): %s (pid %d)", cmdline, pid);
     return 0;
 }
 
@@ -235,7 +235,7 @@ static int handle_new_process_common(
                 libvchan_close(data_vchan);
                 return exit_code;
             }
-            LOG(INFO, "executed %s pid %d", cmdline, pid);
+            LOG(INFO, "executed: %s (pid %d)", cmdline, pid);
             break;
         default:
             LOG(ERROR, "unknown request type: %d", type);

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -1006,6 +1006,8 @@ int main(int argc, char **argv)
     int max;
     sigset_t chld_set;
 
+    setup_logging("qrexec-agent");
+
     int opt;
     while (1) {
         opt = getopt_long(argc, argv, "ha:s:S", longopts, NULL);

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -138,7 +138,7 @@ static struct pam_conv conv = {
  * If dom0 sends overly long cmd, it will probably crash qrexec-agent (unless
  * process can allocate up to 4GB on both stack and heap), sorry.
  */
-_Noreturn void do_exec(char *cmd, const char *user)
+_Noreturn void do_exec(const char *cmd, const char *user)
 {
 #ifdef HAVE_PAM
     int retval, status;

--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -34,7 +34,7 @@
 
 int handle_handshake(libvchan_t *ctrl);
 void handle_vchan_error(const char *op);
-_Noreturn void do_exec(char *cmd, const char *user);
+_Noreturn void do_exec(const char *cmd, const char *user);
 /* call before fork() for service handling process (either end) */
 void prepare_child_env(void);
 

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -136,6 +136,8 @@ int main(int argc, char **argv)
     int opt;
     const char *agent_trigger_path = QREXEC_AGENT_TRIGGER_PATH;
 
+    setup_logging("qrexec-client-vm");
+
     // TODO: this should be in process_io
     signal(SIGPIPE, SIG_IGN);
 

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -39,7 +39,7 @@ _Noreturn void handle_vchan_error(const char *op)
     exit(1);
 }
 
-_Noreturn void do_exec(char *cmd __attribute__((unused)), char const* user __attribute__((__unused__))) {
+_Noreturn void do_exec(const char *cmd __attribute__((unused)), char const* user __attribute__((__unused__))) {
     LOG(ERROR, "BUG: do_exec function shouldn't be called!");
     abort();
 }

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -81,6 +81,8 @@ int main(int argc, char **argv) {
     struct sockaddr_un peer;
     unsigned int addrlen;
 
+    setup_logging("qrexec-fork-server");
+
     if (argc == 2) {
         socket_path = argv[1];
     } else if (argc == 1) {

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -52,13 +52,13 @@ void do_exec(char *cmd, const char *user __attribute__((unused)))
         shell = "/bin/sh";
 
     execl(shell, basename(shell), "-c", cmd, NULL);
-    perror("execl");
+    PERROR("execl");
     exit(1);
 }
 
 _Noreturn void handle_vchan_error(const char *op)
 {
-    fprintf(stderr, "Error while vchan %s, exiting\n", op);
+    PERROR("Error while vchan %s, exiting", op);
     exit(1);
 }
 
@@ -81,13 +81,12 @@ int main(int argc, char **argv) {
     struct sockaddr_un peer;
     unsigned int addrlen;
 
-
     if (argc == 2) {
         socket_path = argv[1];
     } else if (argc == 1) {
         /* this will be leaked, but we don't care as the process will then terminate */
         if (asprintf(&socket_path, QREXEC_FORK_SERVER_SOCKET, getenv("USER")) < 0) {
-            fprintf(stderr, "Memory allocation failed\n");
+            PERROR("Memory allocation failed");
             exit(1);
         }
     } else {
@@ -97,13 +96,13 @@ int main(int argc, char **argv) {
 
     s = get_server_socket(socket_path);
     if (fcntl(s, F_SETFD, O_CLOEXEC) < 0) {
-        perror("fcntl");
+        PERROR("fcntl");
         exit(1);
     }
     /* fork into background */
     switch (fork()) {
         case -1:
-            perror("fork");
+            PERROR("fork");
             exit(1);
         case 0:
             break;

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -36,7 +36,7 @@
 extern char **environ;
 const bool qrexec_is_fork_server = true;
 
-void do_exec(char *cmd, const char *user __attribute__((unused)))
+void do_exec(const char *cmd, const char *user __attribute__((unused)))
 {
     char *shell;
 

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -194,7 +194,7 @@ static void sigchld_handler(int x __attribute__((__unused__)))
 }
 
 /* called from do_fork_exec */
-static _Noreturn void do_exec(char *prog, const char *username __attribute__((unused)))
+static _Noreturn void do_exec(const char *prog, const char *username __attribute__((unused)))
 {
     /* avoid calling qubes-rpc-multiplexer through shell */
     exec_qubes_rpc_if_requested(prog, environ);

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -444,6 +444,8 @@ int main(int argc, char **argv)
     struct service_params svc_params;
     int data_protocol_version;
 
+    setup_logging("qrexec-client");
+
     while ((opt = getopt_long(argc, argv, "hd:l:ec:tTw:W", longopts, NULL)) != -1) {
         switch (opt) {
             case 'd':

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -792,7 +792,7 @@ static int connect_daemon_socket(
         } else if (!strncmp(response, "result=deny\n", sizeof("result=deny\n")-1)) {
             return 1;
         } else {
-            warnx("invalid response");
+            LOG(ERROR, "invalid response: %s", response);
             return -1;
         }
     }
@@ -835,9 +835,9 @@ static void handle_execute_service(
                                    target_domain, service_name, request_id);
     if (result >= 0) {
         _exit(result);
-    } else {
-        warnx("invalid response");
     }
+
+    LOG(ERROR, "couldn't invoke qrexec-policy-daemon, using qrexec-policy-exec");
 
     for (i = 3; i < MAX_FDS; i++)
         close(i);

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1121,6 +1121,8 @@ int main(int argc, char **argv)
     int max, vchan_fd;
     sigset_t chld_set;
 
+    setup_logging("qrexec-daemon");
+
     while ((opt=getopt_long(argc, argv, "hqp:D", longopts, NULL)) != -1) {
         switch (opt) {
             case 'q':

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -17,7 +17,7 @@ endif
 
 
 all: libqrexec-utils.so
-libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o
+libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o
 	$(CC) $(LDFLAGS) -Wl,-soname,$@ -o $@ $^ $(VCHANLIBS)
 
 libqrexec-utils.so: libqrexec-utils.so.$(SO_VER)

--- a/libqrexec/buffer.c
+++ b/libqrexec/buffer.c
@@ -31,12 +31,12 @@ static char *limited_malloc(int len)
     char *ret;
     total_mem += len;
     if (total_mem > BUFFER_LIMIT) {
-        fprintf(stderr, "attempt to allocate >BUFFER_LIMIT\n");
+        LOG(ERROR, "attempt to allocate >BUFFER_LIMIT");
         exit(1);
     }
     ret = malloc(len);
     if (!ret) {
-        perror("malloc");
+        PERROR("malloc");
         exit(1);
     }
     return ret;
@@ -72,7 +72,7 @@ void buffer_append(struct buffer *b, const char *data, int len)
     int newsize;
     char *qdata;
     if (len < 0 || len > BUFFER_LIMIT) {
-        fprintf(stderr, "buffer_append %d\n", len);
+        LOG(ERROR, "buffer_append %d", len);
         exit(1);
     }
     if (len == 0)
@@ -91,7 +91,7 @@ void buffer_remove(struct buffer *b, int len)
     int newsize;
     char *qdata = NULL;
     if (len < 0 || len > b->buflen) {
-        fprintf(stderr, "buffer_remove %d/%d\n", len, b->buflen);
+        LOG(ERROR, "buffer_remove %d/%d", len, b->buflen);
         exit(1);
     }
     newsize = b->buflen - len;

--- a/libqrexec/ioall.c
+++ b/libqrexec/ioall.c
@@ -25,12 +25,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-void perror_wrapper(const char * msg)
-{
-    int prev=errno;
-    perror(msg);
-    errno=prev;
-}
+#include "libqrexec-utils.h"
 
 void set_nonblock(int fd)
 {
@@ -77,12 +72,12 @@ int read_all(int fd, void *buf, int size)
             continue;
         if (ret == 0) {
             errno = 0;
-            fprintf(stderr, "EOF\n");
+            LOG(INFO, "EOF");
             return 0;
         }
         if (ret < 0) {
             if (errno != EAGAIN)
-                perror_wrapper("read");
+                PERROR("read");
             return 0;
         }
         if (got_read == 0) {
@@ -106,11 +101,11 @@ int copy_fd_all(int fdout, int fdin)
         if (!ret)
             break;
         if (ret < 0) {
-            perror_wrapper("read");
+            PERROR("read");
             return 0;
         }
         if (!write_all(fdout, buf, ret)) {
-            perror_wrapper("write");
+            PERROR("write");
             return 0;
         }
     }

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -28,6 +28,8 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <libvchan.h>
+#include <errno.h>
+
 #include <qrexec.h>
 
 struct buffer {
@@ -189,5 +191,22 @@ struct process_io_request {
  * Returns intended exit code (local or remote), but calls exit() on errors.
  */
 int process_io(const struct process_io_request *req);
+
+// Logging
+
+#define DEBUG    1
+#define INFO     2
+#define WARNING  3
+#define ERROR    4
+
+#define LOG(level, fmt, args...) \
+    qrexec_log(level, -1, __FILE__, __LINE__, __func__, fmt, ##args)
+#define LOGE(level, fmt, args...) \
+    qrexec_log(level, errno, __FILE__, __LINE__, __func__, fmt, ##args)
+#define PERROR(fmt, args...) \
+    qrexec_log(ERROR, errno, __FILE__, __LINE__, __func__, fmt, ##args)
+
+void qrexec_log(int level, int errnoval, const char *file, int line,
+                const char *func, const char *fmt, ...);
 
 #endif /* _LIBQREXEC_UTILS_H */

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -209,4 +209,6 @@ int process_io(const struct process_io_request *req);
 void qrexec_log(int level, int errnoval, const char *file, int line,
                 const char *func, const char *fmt, ...);
 
+void setup_logging(const char *program_name);
+
 #endif /* _LIBQREXEC_UTILS_H */

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -42,14 +42,14 @@ struct buffer {
 #define WRITE_STDIN_BUFFERED  1 /* something still in the buffer */
 #define WRITE_STDIN_ERROR     2 /* write error, errno set */
 
-typedef void (do_exec_t)(char *cmdline, const char *user);
+typedef void (do_exec_t)(const char *cmdline, const char *user);
 void register_exec_func(do_exec_t *func);
 /*
  * exec() qubes-rpc-multiplexer if *prog* starts with magic "QUBESRPC" keyword,
  * do not return in that case; pass *envp* to execve() as en environment
  * otherwise, return false without any action
  */
-void exec_qubes_rpc_if_requested(char *prog, char *const envp[]);
+void exec_qubes_rpc_if_requested(const char *prog, char *const envp[]);
 
 void buffer_init(struct buffer *b);
 void buffer_free(struct buffer *b);
@@ -78,7 +78,7 @@ int fork_and_flush_stdin(int fd, struct buffer *buffer);
  * @return 0 if it spawned (or might have spawned) an external process,
  * a (positive) errno value otherwise.
  */
-int execute_qubes_rpc_command(char *cmdline, int *pid, int *stdin_fd,
+int execute_qubes_rpc_command(const char *cmdline, int *pid, int *stdin_fd,
                               int *stdout_fd, int *stderr_fd,
                               bool strip_username, struct buffer *buffer);
 void wait_for_vchan_or_argfd(libvchan_t *vchan, int max, fd_set *rdset,

--- a/libqrexec/log.c
+++ b/libqrexec/log.c
@@ -1,0 +1,76 @@
+/*
+ * The Qubes OS Project, http://www.qubes-os.org
+ *
+ * Copyright (C) 2020 Paweł Marczewski <pawel@invisiblethingslab.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <time.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include "libqrexec-utils.h"
+
+static const char *program_name = "qrexec";
+
+static void log_time() {
+    const size_t buf_len = 32;
+    char buf[buf_len];
+    struct tm tm_buf;
+    struct tm *tm;
+    struct timeval tv;
+
+    if (gettimeofday(&tv, NULL) < 0)
+        return;
+
+    if (!(tm = localtime_r(&tv.tv_sec, &tm_buf)))
+        return;
+
+    strftime(buf, buf_len, "%Y-%m-%d %H:%M:%S", tm);
+    fprintf(stderr, "%s.%03d ", buf, (int)(tv.tv_usec / 1000));
+}
+
+static void qrexec_logv(__attribute__((unused)) int level, int errnoval,
+                        const char *file, int line,
+                        const char *func, const char *fmt, va_list ap) {
+    const size_t buf_len = 64;
+    char buf[buf_len];
+    char *err;
+    int _errno = errno;
+
+    log_time();
+    fprintf(stderr, "%s[%d]: ", program_name, getpid());
+    fprintf(stderr, "%s:%d:%s: ", file, line, func);
+    vfprintf(stderr, fmt, ap);
+    if (errnoval >= 0 && (err = strerror_r(errnoval, buf, buf_len)))
+        fprintf(stderr, ": %s", err);
+    fprintf(stderr, "\n");
+    fflush(stderr);
+    errno = _errno;
+}
+
+void qrexec_log(int level, int errnoval, const char *file, int line,
+                const char *func, const char *fmt, ...) {
+    va_list ap;
+    va_start(ap, fmt);
+    qrexec_logv(level, errnoval, file, line, func, fmt, ap);
+    va_end(ap);
+}

--- a/libqrexec/log.c
+++ b/libqrexec/log.c
@@ -29,7 +29,7 @@
 
 #include "libqrexec-utils.h"
 
-static const char *program_name = "qrexec";
+static const char *qrexec_program_name = "qrexec";
 
 static void log_time() {
     const size_t buf_len = 32;
@@ -57,7 +57,7 @@ static void qrexec_logv(__attribute__((unused)) int level, int errnoval,
     int _errno = errno;
 
     log_time();
-    fprintf(stderr, "%s[%d]: ", program_name, getpid());
+    fprintf(stderr, "%s[%d]: ", qrexec_program_name, getpid());
     fprintf(stderr, "%s:%d:%s: ", file, line, func);
     vfprintf(stderr, fmt, ap);
     if (errnoval >= 0 && (err = strerror_r(errnoval, buf, buf_len)))
@@ -73,4 +73,8 @@ void qrexec_log(int level, int errnoval, const char *file, int line,
     va_start(ap, fmt);
     qrexec_logv(level, errnoval, file, line, func, fmt, ap);
     va_end(ap);
+}
+
+void setup_logging(const char *program_name) {
+    qrexec_program_name = program_name;
 }

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -32,7 +32,7 @@
 
 static _Noreturn void handle_vchan_error(const char *op)
 {
-    fprintf(stderr, "Error while vchan %s, exiting\n", op);
+    LOG(ERROR, "Error while vchan %s, exiting", op);
     exit(1);
 }
 
@@ -59,7 +59,7 @@ static void close_stdin(int fd, bool restore_block) {
         if (errno == ENOTSOCK)
             close(fd);
         else
-            perror("shutdown close_stdin");
+            PERROR("shutdown close_stdin");
     }
 }
 
@@ -76,7 +76,7 @@ static void close_stdout(int fd, bool restore_block) {
         if (errno == ENOTSOCK)
             close(fd);
         else
-            perror("shutdown close_stdout");
+            PERROR("shutdown close_stdout");
     }
 }
 
@@ -179,7 +179,7 @@ int process_io(const struct process_io_request *req) {
                        (errno == EINTR || errno == EBUSY));
                 // other errors are fatal
                 if (errno) {
-                    fputs("Fatal error from dup3()\n", stderr);
+                    PERROR("dup3");
                     abort();
                 }
             } else {
@@ -228,7 +228,7 @@ int process_io(const struct process_io_request *req) {
             if (errno == EINTR)
                 continue;
             else {
-                perror("pselect");
+                PERROR("pselect");
                 /* TODO */
                 break;
             }
@@ -308,7 +308,7 @@ int process_io(const struct process_io_request *req) {
             else
                 local_status = WEXITSTATUS(status);
         } else
-            perror("waitpid");
+            PERROR("waitpid");
     }
 
     if (!is_service)

--- a/libqrexec/remote.c
+++ b/libqrexec/remote.c
@@ -110,9 +110,11 @@ int handle_remote_data(
             case MSG_DATA_EXIT_CODE:
                 /* remote process exited, so there is no sense to send any data
                  * to it */
-                if (hdr.len < sizeof(*status))
+                if (hdr.len < sizeof(*status)) {
+                    LOG(ERROR, "MSG_DATA_EXIT_CODE too short: " PRIu32 " < %zu",
+                        hdr.len, sizeof(*status));
                     *status = 255;
-                else
+                } else
                     memcpy(status, buf, sizeof(*status));
                 rc = REMOTE_EXITED;
                 goto out;

--- a/libqrexec/txrx-vchan.c
+++ b/libqrexec/txrx-vchan.c
@@ -27,6 +27,8 @@
 #include <sys/select.h>
 #include <libvchan.h>
 
+#include "libqrexec-utils.h"
+
 int wait_for_vchan_or_argfd_once(libvchan_t *ctrl, int max, fd_set * rdset, fd_set * wrset)
 {
     int vfd, ret;
@@ -52,18 +54,18 @@ int wait_for_vchan_or_argfd_once(libvchan_t *ctrl, int max, fd_set * rdset, fd_s
     ret = pselect(max, rdset, wrset, NULL, &tv, &empty_set);
     if (ret < 0) {
         if (errno != EINTR) {
-            perror("select");
+            PERROR("select");
             exit(1);
         } else {
             FD_ZERO(rdset);
             FD_ZERO(wrset);
-            fprintf(stderr, "eintr\n");
+            LOGE(INFO, "pselect");
             return 1;
         }
 
     }
     if (!libvchan_is_open(ctrl)) {
-        fprintf(stderr, "libvchan_is_eof\n");
+        LOG(ERROR, "libvchan closed");
         exit(0);
     }
     if (FD_ISSET(vfd, rdset))

--- a/libqrexec/txrx-vchan.c
+++ b/libqrexec/txrx-vchan.c
@@ -59,7 +59,6 @@ int wait_for_vchan_or_argfd_once(libvchan_t *ctrl, int max, fd_set * rdset, fd_s
         } else {
             FD_ZERO(rdset);
             FD_ZERO(wrset);
-            LOGE(INFO, "pselect");
             return 1;
         }
 

--- a/libqrexec/unix-server.c
+++ b/libqrexec/unix-server.c
@@ -26,7 +26,8 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
-//#include "qrexec.h"
+
+#include "libqrexec-utils.h"
 
 int get_server_socket(const char *socket_address)
 {
@@ -37,7 +38,7 @@ int get_server_socket(const char *socket_address)
 
     s = socket(AF_UNIX, SOCK_STREAM, 0);
     if (s < 0) {
-        printf("socket() failed\n");
+        PERROR("socket");
         exit(1);
     }
     memset(&sockname, 0, sizeof(sockname));
@@ -46,13 +47,13 @@ int get_server_socket(const char *socket_address)
     sockname.sun_path[sizeof sockname.sun_path - 1] = 0;
 
     if (bind(s, (struct sockaddr *) &sockname, sizeof(sockname)) == -1) {
-        printf("bind() failed\n");
+        PERROR("bind");
         close(s);
         exit(1);
     }
     //      chmod(sockname.sun_path, 0666);
     if (listen(s, 5) == -1) {
-        perror("listen() failed\n");
+        PERROR("listen");
         close(s);
         exit(1);
     }
@@ -67,7 +68,7 @@ int do_accept(int s)
     addrlen = sizeof(peer);
     fd = accept(s, (struct sockaddr *) &peer, &addrlen);
     if (fd == -1) {
-        perror("unix accept");
+        PERROR("unix accept");
         exit(1);
     }
     return fd;

--- a/libqrexec/write-stdin.c
+++ b/libqrexec/write-stdin.c
@@ -74,7 +74,7 @@ int write_stdin(int fd, const char *data, int len, struct buffer *buffer)
     while (written < len) {
         ret = write(fd, data + written, len - written);
         if (ret == 0) {
-            perror("write_stdin: write returns 0 ???");
+            PERROR("write_stdin: write returns 0 ???");
             exit(1);
         }
         if (ret == -1) {
@@ -103,7 +103,7 @@ int fork_and_flush_stdin(int fd, struct buffer *buffer)
         return 0;
     switch (fork()) {
         case -1:
-            perror("fork");
+            PERROR("fork");
             exit(1);
         case 0:
             break;


### PR DESCRIPTION
- Unify (fprintf/perror/fputs)
- Add context info (source, timestamp, PID)
- Log levels are not used yet, but they're there in case we want to silence something later

As a next step, I would add more "info" level messages to qrexec-agent and daemon, so that we know what request failed, not only how.