### PR TITLE
daemon, agent: unify main loop

### DIFF
--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -81,8 +81,14 @@ int fork_and_flush_stdin(int fd, struct buffer *buffer);
 int execute_qubes_rpc_command(const char *cmdline, int *pid, int *stdin_fd,
                               int *stdout_fd, int *stderr_fd,
                               bool strip_username, struct buffer *buffer);
-void wait_for_vchan_or_argfd(libvchan_t *vchan, int max, fd_set *rdset,
-                             fd_set *wrset);
+
+/*
+ * A version of pselect() that also correctly handles vchan's event pending
+ * flag.
+ */
+int pselect_vchan(libvchan_t *ctrl, int nfds, fd_set *rdset, fd_set *wrset,
+                  struct timespec *timeout, const sigset_t *sigmask);
+
 int read_vchan_all(libvchan_t *vchan, void *data, size_t size);
 int write_vchan_all(libvchan_t *vchan, const void *data, size_t size);
 int read_all(int fd, void *buf, int size);


### PR DESCRIPTION
Use a pselect() in the main loop, unblocking the signals during
waiting, same as in process_io().

Still handle incoming vchan messages when outgoing vchan is blocked
(libvchan_buffer_space() too low). This was the case for agent, but
not for daemon.

Create a pselect_vchan() function that handles vchan quirks, but is
closer in semantics to regular pselect().