### PR TITLE
policy/utils: fix pyinotify cleanup

### DIFF
--- a/qrexec/policy/utils.py
+++ b/qrexec/policy/utils.py
@@ -70,10 +70,11 @@ class PolicyCache:
 
     def cleanup(self):
         for wdd in self.watches:
-            self.watch_manager.rm_watch(wdd.values())
+            self.watch_manager.rm_watch(list(wdd.values()))
         self.watches = []
 
-        self.notifier.stop()
+        if self.notifier is not None:
+            self.notifier.stop()
         self.notifier = None
         self.watch_manager = None
 


### PR DESCRIPTION
rm_watch() accepts a list, but not arbitrary iterable. Convert
`dict_values` to `list`.