### PR TITLE
policy: interpret invalid requested target as @default

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -301,7 +301,8 @@ class IntendedTarget(VMToken):
 
         This function check if given value is not only syntactically correct,
         but also if names valid service call target (existing domain, or valid
-        ``'@dispvm'`` like keyword)
+        ``'@dispvm'`` like keyword). If the domain does not exist,
+        returns a DefaultVM.
 
         Args:
             system_info: information about the system
@@ -318,7 +319,11 @@ class IntendedTarget(VMToken):
             raise NotImplementedError()
 
         if self not in system_info['domains']:
-            raise AccessDenied('invalid target: {}'.format(str.__repr__(self)))
+            logging.warning(
+                'qrexec: target %r does not exist, using @default instead',
+                str(self))
+            return DefaultVM('@default',
+                filepath=self.filepath, lineno=self.lineno)
 
         return self
 


### PR DESCRIPTION
If the requested target does not exist, interpret it as it wasn't provided
at all. This prevents the source domain learning if a given target exists
when the policy is set to default `ask` action
(`... @anyvm ask`). In such a case, previous behavior differed based on 
target existence: if it did exist, the user get a prompt, otherwise the 
request is immediately refused.

Note it is still possible to write a policy that allows the source to 
confirm/deny existence of arbitrary domain (for example default `allow` 
action, or denying only `@default` target). But such policy would need to
be specifically configured, it does no longer apply to default
(innocently-looking) policy.

Fixes QubesOS/qubes-issues#5955