### PR TITLE
Fix handling default_target in ask action

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -894,9 +894,23 @@ class Ask(ActionType):
                 'available to choose from'.format(
                     self.rule.filepath, self.rule.lineno))
 
+        default_target = self.default_target
+        if default_target is not None:
+            # expand default DispVM
+            if isinstance(default_target, DispVM):
+                # pylint is confused by the metaclass - default_target is
+                # constructed as Redirect(), but in fact it can be any subclass
+                # pylint: disable=no-member
+                default_target = default_target.get_dispvm_template(
+                    request.source,
+                    system_info=request.system_info)
+            # expand default AdminVM
+            elif isinstance(default_target, AdminVM):
+                default_target = 'dom0'
+
         return request.ask_resolution_type(self.rule, request,
             user=self.user, targets_for_ask=targets_for_ask,
-            default_target=self.default_target)
+            default_target=default_target)
 
 @enum.unique
 class Action(enum.Enum):

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -1151,6 +1151,27 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.target, '@dispvm:default-dvm')
         self.assertEqual(resolution.request.target, '@dispvm')
 
+    def test_054_eval_resolve_dispvm_from_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * @anyvm @anyvm allow target=@dispvm''')
+        resolution = policy.evaluate(_req('test-vm3', 'test-vm1'))
+
+        self.assertIsInstance(resolution, parser.AllowResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.target, '@dispvm:default-dvm')
+        self.assertEqual(resolution.request.target, 'test-vm1')
+
+    def test_055_eval_resolve_dispvm_from_default_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * @anyvm @anyvm ask default_target=@dispvm
+            * * @anyvm @dispvm ask''')
+        resolution = policy.evaluate(_req('test-vm3', 'test-vm1'))
+
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.default_target, '@dispvm:default-dvm')
+        self.assertEqual(resolution.request.target, 'test-vm1')
+
     @unittest.expectedFailure
     def test_060_eval_to_dom0(self):
         policy = parser.TestPolicy(policy='''\
@@ -1171,6 +1192,50 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.rule, policy.rules[0])
         self.assertEqual(resolution.target, '@adminvm')
         self.assertEqual(resolution.request.target, '@adminvm')
+
+    def test_070_eval_to_dom0_ask_default_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * test-vm3 dom0 ask default_target=dom0''')
+        resolution = policy.evaluate(_req('test-vm3', 'dom0'))
+
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.default_target, 'dom0')
+        self.assertEqual(resolution.request.target, '@adminvm')
+        self.assertEqual(resolution.targets_for_ask, ['dom0'])
+
+    def test_071_eval_to_dom0_ask_default_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * test-vm3 dom0 ask default_target=@adminvm''')
+        resolution = policy.evaluate(_req('test-vm3', 'dom0'))
+
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.default_target, 'dom0')
+        self.assertEqual(resolution.request.target, '@adminvm')
+        self.assertEqual(resolution.targets_for_ask, ['dom0'])
+
+    def test_072_eval_to_dom0_ask_default_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * test-vm3 @adminvm ask default_target=dom0''')
+        resolution = policy.evaluate(_req('test-vm3', 'dom0'))
+
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.default_target, 'dom0')
+        self.assertEqual(resolution.request.target, '@adminvm')
+        self.assertEqual(resolution.targets_for_ask, ['dom0'])
+
+    def test_073_eval_to_dom0_ask_default_target(self):
+        policy = parser.TestPolicy(policy='''\
+            * * test-vm3 @adminvm ask default_target=@adminvm''')
+        resolution = policy.evaluate(_req('test-vm3', 'dom0'))
+
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertEqual(resolution.rule, policy.rules[0])
+        self.assertEqual(resolution.default_target, 'dom0')
+        self.assertEqual(resolution.request.target, '@adminvm')
+        self.assertEqual(resolution.targets_for_ask, ['dom0'])
 
     def test_110_handle_user_response_allow(self):
         rule = parser.Rule.from_line(None, '* * @anyvm @anyvm ask',


### PR DESCRIPTION
default_target needs to have keywords expanded before passing to the
confirmation prompt. Otherwise default_target may not match any allowed
targets. That's the case for at least @dispvm and @adminvm.

Fixes QubesOS/qubes-issues#6112