### PR TITLE
policy: adjust call target for allow action too

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -520,7 +520,7 @@ class AllowResolution(AbstractResolution):
 
         target = self.target
 
-        if target == '@adminvm':
+        if target in ('dom0', '@adminvm'):
             cmd = ('QUBESRPC {request.service}{request.argument} '
                    '{request.source} {request.target.type} {request.target.text}').\
                 format(request=self.request)
@@ -839,6 +839,9 @@ class Allow(ActionType):
                     'policy define \'allow\' action to @dispvm at {}:{} '
                     'but no DispVM base is set for this VM'.format(
                         self.rule.filepath, self.rule.lineno))
+        # expand default AdminVM
+        elif target == '@adminvm':
+            target = 'dom0'
 
         if not self.autostart and not self.allow_no_autostart(
                 target, request.system_info):

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -1190,7 +1190,7 @@ class TC_40_evaluate(unittest.TestCase):
 
         self.assertIsInstance(resolution, parser.AllowResolution)
         self.assertEqual(resolution.rule, policy.rules[0])
-        self.assertEqual(resolution.target, '@adminvm')
+        self.assertEqual(resolution.target, 'dom0')
         self.assertEqual(resolution.request.target, '@adminvm')
 
     def test_070_eval_to_dom0_ask_default_target(self):


### PR DESCRIPTION
Similarly to 'ask' default_target parameter, expand actual 'target'
parameter in case of allow action (explicit or implicit via ask). This
makes the '@adminvm' keyword isolated to the policy internal logic, but
when communicating externally, it gets translated to the actual VM name
(which currently always is 'dom0', but may be translated into "local
 AdminVM" in the future).

QubesOS/qubes-issues#6112