### PR TITLE
daemon: fix handling multiple parallel qrexec-policy processes

### DIFF
--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -499,6 +499,7 @@ static int handle_cmdline_body_from_client(int fd, struct msg_header *hdr)
          * code. Avoid also sending MSG_SERVICE_CONNECT twice. */
         for (i = 0; i <= policy_pending_max; i++) {
             if (policy_pending[i].pid &&
+                    policy_pending[i].response_sent == RESPONSE_PENDING &&
                     strncmp(policy_pending[i].params.ident, buf, len) == 0) {
                 break;
             }
@@ -506,12 +507,6 @@ static int handle_cmdline_body_from_client(int fd, struct msg_header *hdr)
         if (i > policy_pending_max) {
             LOG(ERROR, "Connection with ident %s not requested or already handled",
                     policy_pending[i].params.ident);
-            terminate_client(fd);
-            return 0;
-        } else if (policy_pending[i].response_sent != RESPONSE_PENDING) {
-            LOG(ERROR, "Connection with ident %s already handled (%s)",
-                    policy_pending[i].params.ident,
-                    policy_pending[i].response_sent == RESPONSE_ALLOW ? "allow" : "deny");
             terminate_client(fd);
             return 0;
         }

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -529,6 +529,7 @@ int exec_wait_for_session(const char *source_domain) {
         return -1;
     }
 
-    return execl(service_full_path, service_name, source_domain, NULL);
+    setenv("QREXEC_REMOTE_DOMAIN", source_domain, 1);
+    return execl(service_full_path, service_name, NULL);
 }
 // vim: set sw=4 ts=4 sts=4 et:

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -303,7 +303,7 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
         util.make_executable_service(self.tempdir, 'rpc', 'qubes.WaitForSession', '''\
 #!/bin/sh
 read user
-echo "wait for session: arg: $1, user: $user" >{}
+echo "wait for session: arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, user: $user" >{}
 '''.format(log))
         util.make_executable_service(self.tempdir, 'rpc', 'qubes.Service', '''\
 #!/bin/sh
@@ -321,7 +321,7 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
         target.send_message(qrexec.MSG_DATA_STDIN, b'')
         messages = target.recv_all_messages()
         self.assertListEqual(util.sort_messages(messages), [
-            (qrexec.MSG_DATA_STDOUT, (b'wait for session: arg: domX, user: ' +
+            (qrexec.MSG_DATA_STDOUT, (b'wait for session: arg: , remote domain: domX, user: ' +
                                       user.encode() + b'\n')),
             (qrexec.MSG_DATA_STDOUT, b'arg: arg, remote domain: domX, input: stdin data\n'),
             (qrexec.MSG_DATA_STDOUT, b''),

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -308,6 +308,7 @@ echo "wait for session: arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, user: $us
         util.make_executable_service(self.tempdir, 'rpc', 'qubes.Service', '''\
 #!/bin/sh
 cat {}
+sleep 0.1
 read input
 echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
 '''.format(log))

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -631,7 +631,7 @@ class TestClient(unittest.TestCase):
         log = os.path.join(self.tempdir, 'wait-for-session.log')
         util.make_executable_service(self.tempdir, 'rpc', 'qubes.WaitForSession', '''\
 #!/bin/sh
-echo "wait for session: arg: $1" >{}
+echo "wait for session: remote domain: $QREXEC_REMOTE_DOMAIN" >{}
 '''.format(log))
         util.make_executable_service(self.tempdir, 'rpc', 'qubes.Service', '''\
         #!/bin/sh
@@ -649,7 +649,7 @@ echo "wait for session: arg: $1" >{}
         source.send_message(qrexec.MSG_DATA_STDIN, b'stdin data\n')
         source.send_message(qrexec.MSG_DATA_STDIN, b'')
         self.assertEqual(source.recv_all_messages(), [
-            (qrexec.MSG_DATA_STDOUT, b'wait for session: arg: src_domain\n'),
+            (qrexec.MSG_DATA_STDOUT, b'wait for session: remote domain: src_domain\n'),
             (qrexec.MSG_DATA_STDOUT, b'arg: arg, remote domain: src_domain, '
                                      b'input: stdin data\n'),
             (qrexec.MSG_DATA_STDOUT, b''),

--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -38,7 +38,6 @@ from gi.repository import Gtk, Gdk, GdkPixbuf, GObject, GLib, Gio
 
 # pylint: disable=wrong-import-order
 import gbulb
-gbulb.install()
 
 from .. import POLICY_AGENT_SOCKET_PATH
 from ..utils import sanitize_domain_name, sanitize_service_name
@@ -586,6 +585,7 @@ parser.add_argument(
 def main():
     args = parser.parse_args()
 
+    gbulb.install()
     agent = PolicyAgent(args.socket_path)
 
     loop = asyncio.get_event_loop()

--- a/qubes-rpc-dom0/qubes.WaitForSession
+++ b/qubes-rpc-dom0/qubes.WaitForSession
@@ -2,14 +2,14 @@
 
 # Waits for qubes-guid to become available for a given domain.
 
-if [ -z "$1" ]; then
-    echo "Usage: $0 source_domain" >&2
+if [ -z "$QREXEC_REMOTE_DOMAIN" ]; then
+    echo "QREXEC_REMOTE_DOMAIN variable needs to be set" >&2
     exit 1
 fi
 
 # Traverse /var/run/qubes/qrexec.NAME -> qrexec.ID symlink
 
-qrexec_name_sock="/var/run/qubes/qrexec.$1"
+qrexec_name_sock="/var/run/qubes/qrexec.$QREXEC_REMOTE_DOMAIN"
 
 if ! [ -L "$qrexec_name_sock" ]; then
     echo "$0: $qrexec_name_sock not found, domain might be dead" >&2

--- a/systemd/qubes-qrexec-agent.service
+++ b/systemd/qubes-qrexec-agent.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Qubes remote exec agent
-After=xendriverdomain.service
+After=xendriverdomain.service systemd-user-sessions.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
When service call request arrives, qrexec-daemon spawns separate process
for evaluate the qrexec policy and call back for connection setup via
qrexec-client (if allowed). Since QubesOS/qubes-issues#6120 fix,
qrexec-daemon verifies if the request ident from qrexec-client really
was requested by qrexec-agent and is pending response (avoid responding
twice to the same request). It basically works like this:

1. qrexec-agent sends connection request (with ident X)
2. qrexec-daemon spawns a process for policy evaluation, and save its
   PID associated with request ident (X), plus info that response is
   pending - in a "policy_pending" array
3. policy gets evaluated and when accepted, qrexec-client is called to
   setup the connection
4. qrexec-client connects back to qrexec-daemon, sending ident X +
   connection parameters
5. qrexec-daemon rely the message to qrexe-agent and marks that
   connection as handled
6. policy handling process terminates
7. qrexec-daemon notice its child exited and cleanup related
  "policy_pending" array entry

It is possible that connection is very short and happens entirely
between steps 5 and 6. In this case, qrexec-agent may re-use the same
ident. If subsequent policy evaluation etc, up until step 4 for the
next connection happens before step 7 of previous connection,
qrexec-daemon will refuse the message, as already handled. This is
because it looks for the first maching entry in policy_pending array.

Fix this by looking specifically RESPONSE_PENDING entry with matching
request ident in policy_pending array, instead of just matching request
ident and then checking if it's RESPONSE_PENDING entry. This slightly
reduce verbosity of potential error message (no longer info what the
other response was), but it should be logged by policy handling code
elsewhere already.

QubesOS/qubes-issues#6120