### PR TITLE
agent: do not interrupt established connections on restart

### DIFF
--- a/systemd/qubes-qrexec-agent.service
+++ b/systemd/qubes-qrexec-agent.service
@@ -6,6 +6,7 @@ After=xendriverdomain.service systemd-user-sessions.service
 Type=notify
 ExecStartPre=/bin/sh -c '[ -e /dev/xen/evtchn ] || modprobe xen_evtchn'
 ExecStart=/usr/lib/qubes/qrexec-agent
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Restart only the main process, do not kill children (responsible for
passing data for established connections). This fixes installing updates
(when qrexec is updated too) using Salt or other qrexec service.

QubesOS/qubes-issues#1148