### PR TITLE
process_io: move mutable locals into struct process_io_request

### DIFF
--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -236,6 +236,13 @@ struct process_io_request {
 
     bool replace_chars_stdout;
     bool replace_chars_stderr;
+
+    bool use_stdio_socket;
+
+    /* local and remote statuses */
+    pid_t local_status;
+    pid_t remote_status;
+
     int data_protocol_version;
 
     volatile sig_atomic_t *sigchld;
@@ -249,7 +256,7 @@ struct process_io_request {
  *
  * Returns intended exit code (local or remote), but calls exit() on errors.
  */
-int process_io(const struct process_io_request *req);
+int process_io(struct process_io_request *req);
 
 // Logging
 

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -97,45 +97,39 @@ enum {
     FD_NUM
 };
 
-int process_io(const struct process_io_request *req) {
-    libvchan_t *vchan = req->vchan;
-    int stdin_fd = req->stdin_fd;
-    int stdout_fd = req->stdout_fd;
-    int stderr_fd = req->stderr_fd;
-    struct buffer *stdin_buf = req->stdin_buf;
+int process_io(struct process_io_request *req) {
+    libvchan_t *const vchan = req->vchan;
+    struct buffer *const stdin_buf = req->stdin_buf;
 
-    bool is_service = req->is_service;
-    bool replace_chars_stdout = req->replace_chars_stdout;
-    bool replace_chars_stderr = req->replace_chars_stderr;
-    int data_protocol_version = req->data_protocol_version;
+    bool const is_service = req->is_service;
+    int const data_protocol_version = req->data_protocol_version;
 
-    pid_t local_pid = req->local_pid;
-    volatile sig_atomic_t *sigchld = req->sigchld;
-    volatile sig_atomic_t *sigusr1 = req->sigusr1;
+    pid_t const local_pid = req->local_pid;
+    volatile sig_atomic_t *const sigchld = req->sigchld;
+    volatile sig_atomic_t *const sigusr1 = req->sigusr1;
 
-    pid_t local_status = -1;
-    pid_t remote_status = -1;
-    int stdout_msg_type = is_service ? MSG_DATA_STDOUT : MSG_DATA_STDIN;
-    bool use_stdio_socket = false;
+    req->local_status = -1;
+    req->remote_status = -1;
+    int const stdout_msg_type = is_service ? MSG_DATA_STDOUT : MSG_DATA_STDIN;
+    req->use_stdio_socket = false;
 
-    int ret;
     struct pollfd fds[FD_NUM];
     sigset_t pollmask;
-    struct timespec zero_timeout = { 0, 0 };
-    struct timespec normal_timeout = { 10, 0 };
+    struct timespec const zero_timeout = { 0, 0 };
+    struct timespec const normal_timeout = { 10, 0 };
 
     sigemptyset(&pollmask);
     sigaddset(&pollmask, SIGCHLD);
     sigprocmask(SIG_BLOCK, &pollmask, NULL);
     sigemptyset(&pollmask);
 
-    set_nonblock(stdin_fd);
-    if (stdout_fd != stdin_fd)
-        set_nonblock(stdout_fd);
-    else if ((stdout_fd = fcntl(stdin_fd, F_DUPFD_CLOEXEC, 3)) < 0)
+    set_nonblock(req->stdin_fd);
+    if (req->stdout_fd != req->stdin_fd)
+        set_nonblock(req->stdout_fd);
+    else if ((req->stdout_fd = fcntl(req->stdin_fd, F_DUPFD_CLOEXEC, 3)) < 0)
         abort(); // not worth handling running out of file descriptors
-    if (stderr_fd >= 0)
-        set_nonblock(stderr_fd);
+    if (req->stderr_fd >= 0)
+        set_nonblock(req->stderr_fd);
 
     while(1) {
         /* React to SIGCHLD */
@@ -143,29 +137,29 @@ int process_io(const struct process_io_request *req) {
             int status;
             if (local_pid > 0 && waitpid(local_pid, &status, WNOHANG) > 0) {
                 if (WIFSIGNALED(status))
-                    local_status = 128 + WTERMSIG(status);
+                    req->local_status = 128 + WTERMSIG(status);
                 else
-                    local_status = WEXITSTATUS(status);
-                if (stdin_fd >= 0) {
-                    close_stdin(stdin_fd, !use_stdio_socket);
-                    stdin_fd = -1;
+                    req->local_status = WEXITSTATUS(status);
+                if (req->stdin_fd >= 0) {
+                    close_stdin(req->stdin_fd, !req->use_stdio_socket);
+                    req->stdin_fd = -1;
                 }
             }
             *sigchld = 0;
         }
 
         /* if all done, exit the loop */
-        if (stdin_fd == -1 && stdout_fd == -1 && stderr_fd == -1) {
+        if (req->stdin_fd == -1 && req->stdout_fd == -1 && req->stderr_fd == -1) {
             if (is_service) {
                 /* wait for local process, send exit code */
-                if (!local_pid || local_status >= 0) {
-                    if (send_exit_code(vchan, local_pid ? local_status : 0) < 0)
+                if (!local_pid || req->local_status >= 0) {
+                    if (send_exit_code(vchan, local_pid ? req->local_status : 0) < 0)
                         handle_vchan_error("exit code");
                     break;
                 }
             } else {
                 /* wait for both local and remote process */
-                if ((!local_pid || local_status >= 0) && remote_status >= 0)
+                if ((!local_pid || req->local_status >= 0) && req->remote_status >= 0)
                     break;
             }
         }
@@ -182,21 +176,21 @@ int process_io(const struct process_io_request *req) {
         if (!libvchan_is_open(vchan) &&
                 !libvchan_data_ready(vchan) &&
                 !buffer_len(stdin_buf)) {
-            bool all_closed = stdin_fd == -1 && stdout_fd == -1 && stderr_fd == -1;
-            if (is_service || !(all_closed && remote_status >= 0)) {
+            const bool all_closed = req->stdin_fd == -1 && req->stdout_fd == -1 && req->stderr_fd == -1;
+            if (is_service || !(all_closed && req->remote_status >= 0)) {
                 LOG(ERROR,
                     "vchan connection closed early (fds: %d %d %d, status: %d %d)",
-                    stdin_fd, stdout_fd, stderr_fd, local_status, remote_status);
+                    req->stdin_fd, req->stdout_fd, req->stderr_fd, req->local_status, req->remote_status);
             }
             break;
         }
 
         /* child signaled desire to use single socket for both stdin and stdout */
         if (sigusr1 && *sigusr1) {
-            if (stdout_fd != -1) {
+            if (req->stdout_fd != -1) {
                 do
                     errno = 0;
-                while (dup3(stdin_fd, stdout_fd, O_CLOEXEC) &&
+                while (dup3(req->stdin_fd, req->stdout_fd, O_CLOEXEC) &&
                        (errno == EINTR || errno == EBUSY));
                 // other errors are fatal
                 if (errno) {
@@ -204,19 +198,19 @@ int process_io(const struct process_io_request *req) {
                     abort();
                 }
             } else {
-                stdout_fd = fcntl(stdin_fd, F_DUPFD_CLOEXEC, 3);
+                req->stdout_fd = fcntl(req->stdin_fd, F_DUPFD_CLOEXEC, 3);
                 // all errors are fatal
-                if (stdout_fd < 3)
+                if (req->stdout_fd < 3)
                     abort();
             }
-            use_stdio_socket = true;
+            req->use_stdio_socket = true;
             *sigusr1 = 0;
         }
 
         /* otherwise handle the events */
         fds[FD_STDIN].fd = -1;
-        if (stdin_fd >= 0) {
-            fds[FD_STDIN].fd = stdin_fd;
+        if (req->stdin_fd >= 0) {
+            fds[FD_STDIN].fd = req->stdin_fd;
             if (buffer_len(stdin_buf) > 0)
                 fds[FD_STDIN].events = POLLOUT;
             else
@@ -228,12 +222,12 @@ int process_io(const struct process_io_request *req) {
         fds[FD_STDOUT].fd = -1;
         fds[FD_STDERR].fd = -1;
         if (libvchan_buffer_space(vchan) > (int)sizeof(struct msg_header)) {
-            if (stdout_fd >= 0) {
-                fds[FD_STDOUT].fd = stdout_fd;
+            if (req->stdout_fd >= 0) {
+                fds[FD_STDOUT].fd = req->stdout_fd;
                 fds[FD_STDOUT].events = POLLIN;
             }
-            if (stderr_fd >= 0) {
-                fds[FD_STDERR].fd = stderr_fd;
+            if (req->stderr_fd >= 0) {
+                fds[FD_STDERR].fd = req->stderr_fd;
                 fds[FD_STDERR].events = POLLIN;
             }
         }
@@ -241,19 +235,22 @@ int process_io(const struct process_io_request *req) {
         fds[FD_VCHAN].fd = libvchan_fd_for_select(vchan);
         fds[FD_VCHAN].events = POLLIN;
 
-        if (!buffer_len(stdin_buf) && libvchan_data_ready(vchan) > 0)
-            /* check for other FDs, but exit immediately */
-            ret = ppoll(fds, FD_NUM, &zero_timeout, &pollmask);
-        else
-            ret = ppoll(fds, FD_NUM, &normal_timeout, &pollmask);
+        {
+            int ret;
+            if (!buffer_len(stdin_buf) && libvchan_data_ready(vchan) > 0)
+                /* check for other FDs, but exit immediately */
+                ret = ppoll(fds, FD_NUM, &zero_timeout, &pollmask);
+            else
+                ret = ppoll(fds, FD_NUM, &normal_timeout, &pollmask);
 
-        if (ret < 0) {
-            if (errno == EINTR)
-                continue;
-            else {
-                PERROR("poll");
-                /* TODO */
-                break;
+            if (ret < 0) {
+                if (errno == EINTR)
+                    continue;
+                else {
+                    PERROR("poll");
+                    /* TODO */
+                    break;
+                }
             }
         }
 
@@ -262,83 +259,84 @@ int process_io(const struct process_io_request *req) {
             if (libvchan_wait(vchan) < 0)
                 handle_vchan_error("wait");
 
-        if (stdin_fd >= 0 && fds[FD_STDIN].revents & (POLLHUP | POLLERR)) {
-            close_stdin(stdin_fd, !use_stdio_socket);
-            stdin_fd = -1;
+        if (req->stdin_fd >= 0 && fds[FD_STDIN].revents & (POLLHUP | POLLERR)) {
+            close_stdin(req->stdin_fd, !req->use_stdio_socket);
+            req->stdin_fd = -1;
         }
 
         /* handle_remote_data will check if any data is available */
         switch (handle_remote_data(
-                    vchan, stdin_fd,
-                    &remote_status,
+                    vchan, req->stdin_fd,
+                    &req->remote_status,
                     stdin_buf,
                     data_protocol_version,
-                    replace_chars_stdout > 0,
-                    replace_chars_stderr > 0)) {
+                    req->replace_chars_stdout > 0,
+                    req->replace_chars_stderr > 0)) {
             case REMOTE_ERROR:
                 handle_vchan_error("read");
                 break;
             case REMOTE_EOF:
-                close_stdin(stdin_fd, !use_stdio_socket);
-                stdin_fd = -1;
+                close_stdin(req->stdin_fd, !req->use_stdio_socket);
+                req->stdin_fd = -1;
                 break;
             case REMOTE_EXITED:
                 /* Remote process exited, we don't need any more data from
                  * local FDs. However, don't exit yet, because there might
                  * still be some data in stdin_buf waiting to be flushed.
                  */
-                close_stdout(stdout_fd, !use_stdio_socket);
-                stdout_fd = -1;
-                close_stderr(stderr_fd);
-                stderr_fd = -1;
+                close_stdout(req->stdout_fd, !req->use_stdio_socket);
+                req->stdout_fd = -1;
+                close_stderr(req->stderr_fd);
+                req->stderr_fd = -1;
                 break;
         }
-        if (stdout_fd >= 0 && fds[FD_STDOUT].revents) {
+        if (req->stdout_fd >= 0 && fds[FD_STDOUT].revents) {
             switch (handle_input(
-                        vchan, stdout_fd, stdout_msg_type,
+                        vchan, req->stdout_fd, stdout_msg_type,
                         data_protocol_version)) {
                 case REMOTE_ERROR:
                     handle_vchan_error("send(handle_input stdout)");
                     break;
                 case REMOTE_EOF:
-                    close_stdout(stdout_fd, !use_stdio_socket);
-                    stdout_fd = -1;
+                    close_stdout(req->stdout_fd, !req->use_stdio_socket);
+                    req->stdout_fd = -1;
                     break;
             }
         }
-        if (stderr_fd >= 0 && fds[FD_STDERR].revents) {
+        if (req->stderr_fd >= 0 && fds[FD_STDERR].revents) {
             switch (handle_input(
-                        vchan, stderr_fd, MSG_DATA_STDERR,
+                        vchan, req->stderr_fd, MSG_DATA_STDERR,
                         data_protocol_version)) {
                 case REMOTE_ERROR:
                     handle_vchan_error("send(handle_input stderr)");
                     break;
                 case REMOTE_EOF:
-                    close_stderr(stderr_fd);
-                    stderr_fd = -1;
+                    close_stderr(req->stderr_fd);
+                    req->stderr_fd = -1;
                     break;
             }
         }
     }
     /* make sure that all the pipes/sockets are closed, so the child process
      * (if any) will know that the connection is terminated */
-    close_stdin(stdin_fd, true);
-    close_stdout(stdout_fd, true);
-    close_stderr(stderr_fd);
+    close_stdin(req->stdin_fd, true);
+    close_stdout(req->stdout_fd, true);
+    close_stderr(req->stderr_fd);
+    req->stdin_fd = req->stdout_fd = req->stderr_fd -1;
 
     /* wait for local process, in case we exited early */
-    if (local_pid && local_status < 0) {
+    if (local_pid && req->local_status < 0) {
         int status;
         if (waitpid(local_pid, &status, 0) > 0) {
             if (WIFSIGNALED(status))
-                local_status = 128 + WTERMSIG(status);
+                req->local_status = 128 + WTERMSIG(status);
             else
-                local_status = WEXITSTATUS(status);
+                req->local_status = WEXITSTATUS(status);
         } else
             PERROR("waitpid");
     }
 
     if (!is_service)
-        return remote_status;
-    return local_pid ? local_status : 0;
+        return req->remote_status;
+    return local_pid ? req->local_status : 0;
 }


### PR DESCRIPTION
This is a first step towards making qrexec available as a library, which
requires that it support external event loops.  Therefore, libqrexec
needs to avoid blocking internally.

I am marking this as a draft because on its own, it adds complexity without any benefits.  The benefits will come when there are other consumers of the library, such as qubes-video-companion.  The CPU usage of the receiving side (which is the one making the call) is not trivial and I suspect that sending data over a pipe is partially to blame.

This does not solve QubesOS/qubes-issues#4685, but I suspect it is a good start 🙂.