### PR TITLE
Create a DispVMTemplate instance when needed

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -504,6 +504,8 @@ class AllowResolution(AbstractResolution):
     @classmethod
     def from_ask_resolution(cls, ask_resolution, *, target):
         '''This happens after user manually approved the call'''
+        if target.startswith('@dispvm:'):
+            target = DispVMTemplate(target)
         return cls(
             ask_resolution.rule,
             ask_resolution.request,


### PR DESCRIPTION
Otherwise we assert when trying to launch the DispVM.  The assertion is
still useful to catch bugs elsewhere in the system.

Fixes QubesOS/qubes-issues#6629.