### PR TITLE
Use generic 'guivm' service to tell if running inside GUI VM

### DIFF
--- a/lib/qrexec-policy-agent-autostart
+++ b/lib/qrexec-policy-agent-autostart
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! test -f /var/run/qubes-service/guivm-gui-agent && \
+if ! test -f /var/run/qubes-service/guivm && \
         ! test -f /etc/qubes-release; then
     echo "Not in GuiVM or dom0. Exiting."
     exit 0


### PR DESCRIPTION
... instead of specific guivm-gui-agent.

QubesOS/qubes-issues#4186