### PR TITLE
Fix FD leak causing DispVMs not being cleaned up properly

### DIFF
--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -853,6 +853,9 @@ static void handle_execute_service(
             return;
     }
 
+    for (i = 3; i < MAX_FDS; i++)
+        close(i);
+
     result = connect_daemon_socket(remote_domain_id, remote_domain_name,
                                    target_domain, service_name, request_id);
     if (result >= 0) {
@@ -861,8 +864,6 @@ static void handle_execute_service(
 
     LOG(ERROR, "couldn't invoke qrexec-policy-daemon, using qrexec-policy-exec");
 
-    for (i = 3; i < MAX_FDS; i++)
-        close(i);
     sigemptyset(&sigmask);
     sigprocmask(SIG_SETMASK, &sigmask, NULL);
     signal(SIGCHLD, SIG_DFL);


### PR DESCRIPTION
The qrexec-daemon's child process that talks to the policy daemon was
holding various FD open. They were closed only if communication with the
policy daemon failed, before going to the fallback option of direct
qrexec-policy-exec call. Some of those FDs were used to notify then a
qrexec connection was terminated - by closing it. When they were leaked,
there always was some process keeping them open, so notification
was not delivered.

Fixes QubesOS/qubes-issues#6695
Fixes QubesOS/qubes-issues#6649