### PR TITLE
Switch from ‘select’ to ‘poll’

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -37,7 +37,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
-#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <fcntl.h>

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <stdio.h>

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -381,11 +381,7 @@ static void init(void)
     if (handle_handshake(ctrl_vchan) < 0)
         exit(1);
     old_umask = umask(0);
-    if ((trigger_fd = get_server_socket(agent_trigger_path)) >= FD_SETSIZE) {
-        fprintf(stderr, "TRIGGER_FD too large (got %d, FD_SETSIZE is %d)\n",
-                trigger_fd, FD_SETSIZE);
-        exit(1);
-    }
+    trigger_fd = get_server_socket(agent_trigger_path);
     umask(old_umask);
     register_exec_func(do_exec);
 

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -808,12 +808,11 @@ static void reap_children(void)
     child_exited = 0;
 }
 
-static int fill_fds_for_select(fd_set * rdset, fd_set * wrset)
+static int fill_fds_for_select(fd_set * rdset)
 {
     int max = -1;
     int i;
     FD_ZERO(rdset);
-    FD_ZERO(wrset);
 
     FD_SET(trigger_fd, rdset);
     if (trigger_fd > max)
@@ -966,17 +965,17 @@ int main(int argc, char **argv)
 
     while (!terminate_requested) {
         struct timespec timeout = { 1, 0 };
-        fd_set rdset, wrset;
+        fd_set rdset;
         int ret, max;
 
         if (child_exited)
             reap_children();
 
-        max = fill_fds_for_select(&rdset, &wrset);
+        max = fill_fds_for_select(&rdset);
         if (libvchan_buffer_space(ctrl_vchan) <= (int)sizeof(struct msg_header))
             FD_ZERO(&rdset);
 
-        ret = pselect_vchan(ctrl_vchan, max+1, &rdset, &wrset, &timeout, &selectmask);
+        ret = pselect_vchan(ctrl_vchan, max+1, &rdset, NULL, &timeout, &selectmask);
         if (ret < 0) {
             if (errno == EINTR)
                 continue;

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -30,6 +30,7 @@
 #include <sys/wait.h>
 #include <sys/time.h>
 #include <sys/select.h>
+#include <poll.h>
 #include <errno.h>
 #include <assert.h>
 #include "qrexec.h"
@@ -658,11 +659,10 @@ int main(int argc, char **argv)
             close(s);
             if (wait_connection_end) {
                 /* wait for EOF */
-                fd_set read_fd;
-                assert(wait_connection_end < FD_SETSIZE);
-                FD_ZERO(&read_fd);
-                FD_SET(wait_connection_end, &read_fd);
-                select(wait_connection_end+1, &read_fd, NULL, NULL, 0);
+                struct pollfd fds[1] = {
+                    { .fd = wait_connection_end, .events = POLLIN | POLLHUP, .revents = 0 },
+                };
+                poll(fds, 1, -1);
             }
         } else {
             data_vchan = libvchan_server_init(data_domain, data_port,

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -482,15 +482,19 @@ static void wait_for_vchan_client_with_timeout(libvchan_t *conn, int timeout) {
             FD_ZERO(&rdset);
             FD_SET(fd, &rdset);
             switch (select(fd+1, &rdset, NULL, NULL, &timeout_tv)) {
-                case -1:
-                    if (errno == EINTR) {
-                        break;
-                    }
-                    LOG(ERROR, "vchan connection error");
-                    exit(1);
-                case 0:
-                    LOG(ERROR, "vchan connection timeout");
-                    exit(1);
+            case -1:
+                if (errno == EINTR) {
+                    break;
+                }
+                LOG(ERROR, "vchan connection error");
+                exit(1);
+            case 0:
+                LOG(ERROR, "vchan connection timeout");
+                exit(1);
+            case 1:
+                break;
+            default:
+                abort();
             }
         }
         libvchan_wait(conn);

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1186,7 +1186,7 @@ int main(int argc, char **argv)
         if (ret < 0) {
             if (errno == EINTR)
                 continue;
-            PERROR("pselect");
+            PERROR("ppoll");
             return 1;
         }
 

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -637,6 +637,8 @@ static void handle_message_from_client(int fd)
             }
             terminate_client(fd);
             return;
+        case CLIENT_INVALID:
+            return; /* nothing to do */
         default:
             LOG(ERROR, "Invalid client state %d", clients[fd].state);
             exit(1);
@@ -1205,11 +1207,8 @@ int main(int argc, char **argv)
             handle_message_from_agent();
 
         for (size_t i = 2; i < nfds; i++) {
-            if (fds[i].revents) {
-                int fd = fds[i].fd;
-                if (clients[fd].state != CLIENT_INVALID)
-                    handle_message_from_client(fd);
-            }
+            if (fds[i].revents)
+                handle_message_from_client(fds[i].fd);
         }
     }
 

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -19,7 +19,6 @@
  *
  */
 
-#include <sys/select.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -1029,13 +1028,12 @@ static void handle_message_from_agent(void)
  * to (because its pipe is full) to write_fdset. Return the highest used file
  * descriptor number, needed for the first select() parameter.
  */
-static int fill_fdsets_for_select(fd_set * read_fdset, fd_set * write_fdset)
+static int fill_fdsets_for_select(fd_set * read_fdset)
 {
     int i;
     int max = -1;
 
     FD_ZERO(read_fdset);
-    FD_ZERO(write_fdset);
     assert(max_client_fd < FD_SETSIZE);
     assert(qrexec_daemon_unix_socket_fd < FD_SETSIZE);
     for (i = 0; i <= max_client_fd; i++) {
@@ -1198,7 +1196,8 @@ int main(int argc, char **argv)
         if (child_exited)
             reap_children();
 
-        max = fill_fdsets_for_select(&rdset, &wrset);
+        FD_ZERO(&wrset);
+        max = fill_fdsets_for_select(&rdset);
         if (libvchan_buffer_space(vchan) <= (int)sizeof(struct msg_header))
             FD_ZERO(&rdset);	// vchan full - don't read from clients
 

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -141,13 +141,6 @@ int execute_qubes_rpc_command(const char *cmdline, int *pid, int *stdin_fd,
 int ppoll_vchan(libvchan_t *ctrl, struct pollfd *fds, size_t nfds,
                 struct timespec *timeout, const sigset_t *sigmask);
 
-/*
- * A version of pselect() that also correctly handles vchan's event pending
- * flag.
- */
-int pselect_vchan(libvchan_t *ctrl, int nfds, fd_set *rdset, fd_set *wrset,
-                  struct timespec *timeout, const sigset_t *sigmask);
-
 int read_vchan_all(libvchan_t *vchan, void *data, size_t size);
 int write_vchan_all(libvchan_t *vchan, const void *data, size_t size);
 int read_all(int fd, void *buf, int size);

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -30,6 +30,7 @@
 #include <libvchan.h>
 #include <errno.h>
 #include <sys/select.h>
+#include <poll.h>
 
 #include <qrexec.h>
 
@@ -134,6 +135,12 @@ int fork_and_flush_stdin(int fd, struct buffer *buffer);
 int execute_qubes_rpc_command(const char *cmdline, int *pid, int *stdin_fd,
                               int *stdout_fd, int *stderr_fd,
                               bool strip_username, struct buffer *buffer);
+/*
+ * A version of ppoll() that also correctly handles vchan's event pending
+ * flag.  fds[0] is used internally and fds[0].fd must be equal to -1 on entry.
+ */
+int ppoll_vchan(libvchan_t *ctrl, struct pollfd *fds, size_t nfds,
+                struct timespec *timeout, const sigset_t *sigmask);
 
 /*
  * A version of pselect() that also correctly handles vchan's event pending

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -29,7 +29,6 @@
 #include <stdbool.h>
 #include <libvchan.h>
 #include <errno.h>
-#include <sys/select.h>
 #include <poll.h>
 
 #include <qrexec.h>

--- a/libqrexec/write-stdin.c
+++ b/libqrexec/write-stdin.c
@@ -29,7 +29,7 @@
 #include "libqrexec-utils.h"
 
 /* 
-There is buffered data in "buffer" for client and select()
+There is buffered data in "buffer" for client and poll()
 reports that "fd" is writable. Write as much as possible to fd.
 */
 int flush_client_data(int fd, struct buffer *buffer)


### PR DESCRIPTION
This avoids select()’s FD_SETSIZE limit.  It has been broken up into several commits for ease of review, as a previous attempt to make the entire change at once turned out to be buggy.