### PR TITLE
Add assertions that FD_SETSIZE is not exceeded

### DIFF
--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -460,6 +460,10 @@ static void wait_for_vchan_client_with_timeout(libvchan_t *conn, int timeout) {
         if (timeout) {
             fd_set rdset;
             int fd = libvchan_fd_for_select(conn);
+            if (fd >= FD_SETSIZE) {
+                fprintf(stderr, "vchan fd not less than FD_SETSIZE\n");
+                exit(1);
+            }
 
             /* calculate how much time left until connection timeout expire */
             if (gettimeofday(&now_tv, NULL) == -1) {
@@ -655,6 +659,7 @@ int main(int argc, char **argv)
             if (wait_connection_end) {
                 /* wait for EOF */
                 fd_set read_fd;
+                assert(wait_connection_end < FD_SETSIZE);
                 FD_ZERO(&read_fd);
                 FD_SET(wait_connection_end, &read_fd);
                 select(wait_connection_end+1, &read_fd, NULL, NULL, 0);

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1036,6 +1036,8 @@ static int fill_fdsets_for_select(fd_set * read_fdset, fd_set * write_fdset)
 
     FD_ZERO(read_fdset);
     FD_ZERO(write_fdset);
+    assert(max_client_fd < FD_SETSIZE);
+    assert(qrexec_daemon_unix_socket_fd < FD_SETSIZE);
     for (i = 0; i <= max_client_fd; i++) {
         if (clients[i].state != CLIENT_INVALID) {
             FD_SET(i, read_fdset);

--- a/libqrexec/txrx-vchan.c
+++ b/libqrexec/txrx-vchan.c
@@ -26,6 +26,7 @@
 #include <errno.h>
 #include <sys/select.h>
 #include <libvchan.h>
+#include <assert.h>
 
 #include "libqrexec-utils.h"
 
@@ -36,6 +37,7 @@ int pselect_vchan(libvchan_t *ctrl, int nfds, fd_set *rdset, fd_set *wrset,
     int ret;
 
     vchan_fd = libvchan_fd_for_select(ctrl);
+    assert(vchan_fd < FD_SETSIZE);
     FD_SET(vchan_fd, rdset);
     if (vchan_fd + 1 > nfds)
         nfds = vchan_fd + 1;


### PR DESCRIPTION
Using FD_SET with a file descriptor not less than FD_SETSIZE is
undefined behavior.

Draft because not tested yet.