### PR TITLE
Add SELinux policy for qrexec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ build/
 *.gcov
 *~
 \#*#
+/selinux/*.pp
+/selinux/tmp/

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ install-dom0: all-dom0
 
 all-vm:
 	+$(MAKE) all -C agent
+all-vm-selinux:
+	+$(MAKE) -f /usr/share/selinux/devel/Makefile -C selinux qubes-core-qrexec.pp
 .PHONY: all-vm
 
 install-vm: all-vm
@@ -76,6 +78,9 @@ install-vm: all-vm
 	install -d $(DESTDIR)/$(SYSLIBDIR)/systemd/system -m 755
 	install -t $(DESTDIR)/$(SYSLIBDIR)/systemd/system -m 644 systemd/qubes-qrexec-agent.service
 	install -m 0644 -D qubes-rpc-config/README $(DESTDIR)/etc/qubes/rpc-config/README
+install-vm-selinux:
+	install -m 0644 -D -t $(DESTDIR)/usr/share/selinux/packages selinux/qubes-core-qrexec.pp
+	install -m 0644 -D selinux/qubes-core-qrexec.if $(DESTDIR)/usr/share/selinux/devel/include/contrib/ipp-qubes-core-qrexec.if
 #	install -d $(DESTDIR)/etc/qubes-rpc -m 755
 #	install -t $(DESTDIR)/etc/qubes-rpc -m 755 qubes-rpc/*
 .PHONY: install-vm

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ clean:
 	+$(MAKE) -C libqrexec clean
 	+$(MAKE) -C daemon clean
 	+$(MAKE) -C agent clean
+	rm -rf selinux/*.pp selinux/tmp/
 .PHONY: clean
 
 

--- a/agent/qrexec.pam
+++ b/agent/qrexec.pam
@@ -5,5 +5,8 @@ auth		include		postlogin
 account		sufficient	pam_succeed_if.so uid = 0 use_uid quiet
 account		include		system-auth
 password	include		system-auth
+-session	required	pam_selinux.so close
+-session	required	pam_loginuid.so
+-session	required	pam_selinux.so nottys open
 session		include		system-auth
 session		include		postlogin

--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -48,6 +48,20 @@ Obsoletes:  qubes-core-agent-qrexec < 4.1.0-1
 
 Source0: qubes-core-qrexec-%{version}.tar.gz
 
+Requires: (%{name}-selinux if selinux-policy)
+
+%package selinux
+BuildRequires: selinux-policy
+BuildRequires: selinux-policy-devel
+%{?selinux_requires}
+Requires(post): qubes-core-agent-selinux
+Summary: SELinux policies for qrexec
+License: GPLv2+
+
+%description selinux
+The SELinux policies for qrexec.  You need this package if you want to have
+SELinux enforcing in a qube.
+
 %description
 The Qubes qrexec files for installation on a qube.
 
@@ -56,11 +70,11 @@ The Qubes qrexec files for installation on a qube.
 
 %build
 %{?set_build_flags}
-make all-vm
+make all-vm all-vm-selinux
 #make -C doc PYTHON=%{__python3} SPHINXBUILD=sphinx-build-%{python3_version} man
 
 %install
-make install-vm \
+make install-vm install-vm-selinux \
     DESTDIR=$RPM_BUILD_ROOT \
     UNITDIR=%{_unitdir} \
     PYTHON_SITEPATH=%{python3_sitelib} \
@@ -79,6 +93,18 @@ rm -f %{name}-%{version}
 
 %preun
 %systemd_preun qubes-qrexec-agent.service
+
+%post selinux
+%selinux_modules_install %{_datadir}/selinux/packages/qubes-core-qrexec.pp || :
+
+%postun selinux
+if [ "$1" -eq 0 ]; then
+    %selinux_modules_uninstall %{_datadir}/selinux/packages/qubes-core-qrexec.pp
+fi || :
+
+%posttrans selinux
+%selinux_relabel_post
+exit 0
 
 %posttrans
 # when upgrading from R4.0, %%postun of qubes-core-agent-qrexec will revert
@@ -104,6 +130,10 @@ fi
 /usr/lib/qubes/qrexec-client-vm
 /usr/lib/qubes/qrexec_client_vm
 /lib/systemd/system/qubes-qrexec-agent.service
+
+%files selinux
+%{_datadir}/selinux/devel/include/contrib/ipp-qubes-core-qrexec.if
+%{_datadir}/selinux/packages/qubes-core-qrexec.pp
 
 %changelog
 @CHANGELOG@

--- a/selinux/qubes-core-qrexec.fc
+++ b/selinux/qubes-core-qrexec.fc
@@ -1,0 +1,1 @@
+/usr/lib/qubes/qrexec-agent -- gen_context(system_u:object_r:qubes_qrexec_agent_exec_t,s0)

--- a/selinux/qubes-core-qrexec.if
+++ b/selinux/qubes-core-qrexec.if
@@ -13,7 +13,11 @@
 ## </param>
 interface(`ipp_qubes_qrexec',`
 	gen_require(`
-		attribute qubes_qrexec_domain;
+		type qubes_qrexec_socket_t;
+		type qubes_var_run_t;
+		type local_login_t; # See UGLY HACK in qubes-core-qrexec.te
 	')
-	typeattribute $1 qubes_qrexec_domain;
+	stream_connect_pattern($1, qubes_var_run_t, qubes_qrexec_socket_t, local_login_t)
+	dev_rw_xen($1)
+	allow $1 qubes_qrexec_socket_t:sock_file rw_sock_file_perms;
 ')

--- a/selinux/qubes-core-qrexec.if
+++ b/selinux/qubes-core-qrexec.if
@@ -1,0 +1,19 @@
+## <summary>
+##	Use qrexec to communicate with other qubes.  This can have potentially
+##	unbounded side-effects, depending on the qrexec policy and what services
+##	other qubes are running.  Furthermore, depending on how qrexec is
+##	implemented, this may grant extensive additional permissions, up to and
+##	including the ability to escalate to root.  This permission must never be
+##	granted to untrusted domains.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed access
+## </summary>
+## </param>
+interface(`ipp_qubes_qrexec',`
+	gen_require(`
+		attribute qubes_qrexec_domain;
+	')
+	typeattribute $1 qubes_qrexec_domain;
+')

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -43,6 +43,7 @@ allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };
 files_pid_file(qubes_qrexec_socket_t)
 su_exec(qubes_qrexec_agent_t)
 dev_rw_xen(qubes_qrexec_agent_t)
+systemd_exec_systemctl(qubes_qrexec_agent_t)
 allow qubes_qrexec_agent_t xauth_exec_t:file execute;
 type_transition qubes_qrexec_agent_t qubes_var_run_t:sock_file qubes_qrexec_socket_t "qrexec-agent";
 manage_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_qrexec_socket_t)

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -54,3 +54,4 @@ manage_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_qrexec_so
 write_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_var_run_t)
 allow domain qubes_qrexec_agent_t:unix_stream_socket { rw_inherited_sock_file_perms ioctl };
 allow qubes_qrexec_agent_t domain:unix_stream_socket connectto;
+allow qubes_qrexec_agent_t file_type:sock_file { rw_sock_file_perms ioctl };

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -39,7 +39,7 @@ init_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t)
 init_ranged_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t, s0 - mcs_systemhigh)
 allow qubes_qrexec_agent_t tmpfs_t:dir create;
 allow { qubes_qrexec_agent_t init_t } self:passwd rootok;
-allow qubes_qrexec_agent_t init_t:system start;
+systemd_start_systemd_services(qubes_qrexec_agent_t)
 allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };
 files_pid_file(qubes_qrexec_socket_t)
 su_exec(qubes_qrexec_agent_t)

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -39,6 +39,7 @@ init_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t)
 init_ranged_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t, s0 - mcs_systemhigh)
 allow qubes_qrexec_agent_t tmpfs_t:dir create;
 allow { qubes_qrexec_agent_t init_t } self:passwd rootok;
+allow qubes_qrexec_agent_t init_t:system start;
 allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };
 files_pid_file(qubes_qrexec_socket_t)
 su_exec(qubes_qrexec_agent_t)

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -40,6 +40,7 @@ init_ranged_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t, s0 - 
 allow qubes_qrexec_agent_t tmpfs_t:dir create;
 allow { qubes_qrexec_agent_t init_t } self:passwd rootok;
 init_start(qubes_qrexec_agent_t)
+allow qubes_qrexec_agent_t systemd_unit_file_t:service manage_service_perms;
 init_start_transient_unit(qubes_qrexec_agent_t)
 systemd_start_systemd_services(qubes_qrexec_agent_t)
 allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -39,6 +39,8 @@ init_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t)
 init_ranged_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t, s0 - mcs_systemhigh)
 allow qubes_qrexec_agent_t tmpfs_t:dir create;
 allow { qubes_qrexec_agent_t init_t } self:passwd rootok;
+init_start(qubes_qrexec_agent_t)
+init_start_transient_unit(qubes_qrexec_agent_t)
 systemd_start_systemd_services(qubes_qrexec_agent_t)
 allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };
 files_pid_file(qubes_qrexec_socket_t)

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -1,0 +1,47 @@
+policy_module(qubes-core-qrexec, 0.0.1)
+
+require {
+	type staff_t, init_t, initrc_t, sysadm_t, xauth_exec_t, local_login_t, tmpfs_t, qubes_var_run_t;
+	class passwd rootok;
+}
+
+### BEGIN UGLY HACK ###
+# There is no good way to use a custom label for a login program such as qrexec.
+# There are various bad ways, but they either don't always work or require
+# editing system files.  local_login_t is the best option available for the
+# qrexec agent, so use it.  Use aliases (defined here) so that this can easily
+# be fixed later.
+define(`qubes_qrexec_agent_t', `local_login_t')
+### END UGLY HACK ###
+
+# The attribute `qubes_qrexec_domain` determines which confined domains that are
+# allowed to use qrexec.
+attribute qubes_qrexec_domain;
+stream_connect_pattern(qubes_qrexec_domain, qubes_var_run_t, qubes_qrexec_socket_t, qubes_qrexec_agent_t)
+dev_rw_xen(qubes_qrexec_domain)
+allow qubes_qrexec_domain qubes_qrexec_socket_t:sock_file rw_sock_file_perms;
+
+# staff_t and sysadm_t can use qrexec.  Unprivileged user domains (such as user_t)
+# cannot.
+ipp_qubes_qrexec(staff_t)
+ipp_qubes_qrexec(sysadm_t)
+
+# init scripts can use qrexec
+ipp_qubes_qrexec(init_t)
+ipp_qubes_qrexec(initrc_t)
+
+type qubes_qrexec_agent_exec_t;
+type qubes_qrexec_socket_t;
+init_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t)
+init_ranged_daemon_domain(qubes_qrexec_agent_t, qubes_qrexec_agent_exec_t, s0 - mcs_systemhigh)
+allow qubes_qrexec_agent_t tmpfs_t:dir create;
+allow { qubes_qrexec_agent_t init_t } self:passwd rootok;
+allow qubes_qrexec_agent_t self:netlink_selinux_socket { bind create };
+files_pid_file(qubes_qrexec_socket_t)
+su_exec(qubes_qrexec_agent_t)
+dev_rw_xen(qubes_qrexec_agent_t)
+allow qubes_qrexec_agent_t xauth_exec_t:file execute;
+type_transition qubes_qrexec_agent_t qubes_var_run_t:sock_file qubes_qrexec_socket_t "qrexec-agent";
+manage_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_qrexec_socket_t)
+write_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_var_run_t)
+allow domain qubes_qrexec_agent_t:unix_stream_socket { rw_inherited_sock_file_perms ioctl };

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -2,6 +2,7 @@ policy_module(qubes-core-qrexec, 0.0.1)
 
 require {
 	type staff_t, init_t, initrc_t, sysadm_t, xauth_exec_t, local_login_t, tmpfs_t, qubes_var_run_t;
+	type user_t;
 	class passwd rootok;
 }
 
@@ -14,17 +15,19 @@ require {
 define(`qubes_qrexec_agent_t', `local_login_t')
 ### END UGLY HACK ###
 
-# The attribute `qubes_qrexec_domain` determines which confined domains that are
-# allowed to use qrexec.
-attribute qubes_qrexec_domain;
-stream_connect_pattern(qubes_qrexec_domain, qubes_var_run_t, qubes_qrexec_socket_t, qubes_qrexec_agent_t)
-dev_rw_xen(qubes_qrexec_domain)
-allow qubes_qrexec_domain qubes_qrexec_socket_t:sock_file rw_sock_file_perms;
-
 # staff_t and sysadm_t can use qrexec.  Unprivileged user domains (such as user_t)
-# cannot.
+# cannot unless a boolean is set.  This is important if one e.g. has a qube that
+# provides shell accounts to mutually distrusting users, although Qubes OS does not
+# consider this to be a good idea the vast majority of the time.
 ipp_qubes_qrexec(staff_t)
 ipp_qubes_qrexec(sysadm_t)
+
+# Allow user_t to use qrexec.  This is mostly equivalent to unconfined root access!
+# In particular, qrexec does not care about the initiating user, only the qube.
+gen_bool(qubes_user_t_can_use_qrexec, false)
+if (qubes_user_t_can_use_qrexec) {
+	ipp_qubes_qrexec(user_t)
+}
 
 # init scripts can use qrexec
 ipp_qubes_qrexec(init_t)

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -53,3 +53,4 @@ type_transition qubes_qrexec_agent_t qubes_var_run_t:sock_file qubes_qrexec_sock
 manage_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_qrexec_socket_t)
 write_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_var_run_t)
 allow domain qubes_qrexec_agent_t:unix_stream_socket { rw_inherited_sock_file_perms ioctl };
+allow qubes_qrexec_agent_t domain:unix_stream_socket connectto;

--- a/systemd/qubes-qrexec-agent.service
+++ b/systemd/qubes-qrexec-agent.service
@@ -4,7 +4,7 @@ After=xendriverdomain.service systemd-user-sessions.service
 
 [Service]
 Type=notify
-ExecStartPre=/bin/sh -c '[ -e /dev/xen/evtchn ] || modprobe xen_evtchn'
+ExecStartPre=+/bin/sh -c '[ -e /dev/xen/evtchn ] || modprobe xen_evtchn'
 ExecStart=/usr/lib/qubes/qrexec-agent
 KillMode=process
 SELinuxContext=system_u:system_r:local_login_t:s0-s0:c0.c1023

--- a/systemd/qubes-qrexec-agent.service
+++ b/systemd/qubes-qrexec-agent.service
@@ -7,6 +7,7 @@ Type=notify
 ExecStartPre=/bin/sh -c '[ -e /dev/xen/evtchn ] || modprobe xen_evtchn'
 ExecStart=/usr/lib/qubes/qrexec-agent
 KillMode=process
+SELinuxContext=system_u:system_r:local_login_t:s0-s0:c0.c1023
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows qrexec to run on systems with SELinux in enforcing mode.  Part of QubesOS/qubes-issues#4239.

~~Marked as draft because I have not tested it yet.  In particular, there might be problems with the packaging.~~ Tested and problems fixed.