### PR TITLE
policy: fix reporting failed target start

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -531,12 +531,16 @@ class AllowResolution(AbstractResolution):
                   '{request.source}'.format(
                        user=(self.user or 'DEFAULT'), request=self.request)
 
-        if target.startswith('@dispvm:'):
-            target = self.spawn_dispvm()
-            dispvm = True
-        else:
-            self.ensure_target_running()
-            dispvm = False
+        try:
+            if target.startswith('@dispvm:'):
+                target = self.spawn_dispvm()
+                dispvm = True
+            else:
+                self.ensure_target_running()
+                dispvm = False
+        except QubesMgmtException as err:
+            raise ExecutionFailed(
+                    'Failed to start the target: {}'.format(exc)) from err
 
         qrexec_opts = ['-d', target, '-c', caller_ident, '-E']
         if dispvm:

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -1448,7 +1448,7 @@ class TC_40_evaluate(unittest.TestCase):
             rule, request, user=None, target='test-vm2')
         mock_qubesd_call.side_effect = \
             exc.QubesMgmtException('QubesVMError')
-        with self.assertRaises(exc.QubesMgmtException):
+        with self.assertRaises(exc.ExecutionFailed):
             await resolution.execute('some-ident')
         self.assertEqual(mock_qubesd_call.mock_calls,
             [unittest.mock.call('test-vm2', 'admin.vm.Start')])


### PR DESCRIPTION
Report it as proper failed call exception, so that policy-daemon will
report it back properly as refused call. Otherwise qrexec-client will
fallback to a direct qrexec-policy-exec call. This would cause second
(unexpected) start try.

Fixes QubesOS/qubes-issues#7031