### PR TITLE
Fix error return value in allocate_vchan_port

### DIFF
--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -432,7 +432,7 @@ static int allocate_vchan_port(int connect_domain)
             return VCHAN_BASE_DATA_PORT+i;
         }
     }
-    return -1;
+    return 0;
 }
 
 static void handle_new_client()


### PR DESCRIPTION
If no port can be allocated, allocate_vchan_port() should return 0, not
-1.

Fixes QubesOS/qubes-issues#7201