### PR TITLE
policy: fix notification on refused autostart

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -852,7 +852,9 @@ class Allow(ActionType):
         if not self.autostart and not self.allow_no_autostart(
                 target, request.system_info):
             raise AccessDenied(
-                'target {} is denied because it would require autostart')
+                'target {} is denied because it would require autostart'
+                .format(target),
+                notify=self.notify)
 
         return request.allow_resolution_type(self.rule, request,
             user=self.user, target=target)


### PR DESCRIPTION
- fill the call target in the message
- consider 'notify=yes'/'notify=no' when showing the message

Reported by @adrelanos
Fixes QubesOS/qubes-issues#7267