### PR TITLE
Fix parsing legacy policy files

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -1051,12 +1051,19 @@ class Rule:
             PolicySyntaxError: when syntax error is found
         '''
         try:
-            source, target, action, *params = line.split()
+            source, target, *action_and_params = line.split()
         except ValueError as err:
             raise PolicySyntaxError(
                 filepath, lineno, 'wrong number of fields') from err
 
-        params = tuple(itertools.chain(*(p.split(',') for p in params)))
+        action_and_params = tuple(itertools.chain(
+                    *(p.split(',') for p in action_and_params)))
+
+        try:
+            action, *params = action_and_params
+        except ValueError as err:
+            raise PolicySyntaxError(
+                filepath, lineno, 'wrong number of fields') from err
 
         return cls(service, argument, source, target, action, params,
             policy=policy, filepath=filepath, lineno=lineno)

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -733,6 +733,19 @@ class TC_11_Rule_service(unittest.TestCase):
         self.assertIsNone(line.action.user)
         self.assertEqual(line.action.default_target, '@adminvm')
 
+    def test_025_line_simple_compat(self):
+        line = parser.Rule.from_line_service(None, 'test.Service', '+argument',
+            '@anyvm @default ask,default_target=test-vm1',
+            filepath='filename', lineno=12)
+        self.assertEqual(line.filepath, 'filename')
+        self.assertEqual(line.lineno, 12)
+        self.assertIsInstance(line.action, parser.Action.ask.value)
+        self.assertEqual(line.source, '@anyvm')
+        self.assertEqual(line.target, '@default')
+        self.assertIsNone(line.action.target)
+        self.assertIsNone(line.action.user)
+        self.assertEqual(line.action.default_target, 'test-vm1')
+
     def test_030_line_invalid(self):
         invalid_lines = [
             '@dispvm @default allow',  # @dispvm can't be a source


### PR DESCRIPTION
Policy files in /etc/qubes-rpc/policy use coma to separate action from
parameters, not only between parameters. Fix that.

Fixes QubesOS/qubes-issues#7122