### PR TITLE
In PKGBUILD: copy instead of symlink

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -29,10 +29,11 @@ md5sums=() #generate with 'makepkg -g'
 
 
 build() {
+    rm $srcdir/* -rf
     for source in libqrexec agent qrexec policy-agent-extra lib systemd qubes-rpc-config Makefile setup.py version
     do
         # shellcheck disable=SC2154
-        (ln -s "$srcdir/../$source" "$srcdir/$source")
+        (cp -r "$srcdir/../$source" "$srcdir/$source")
     done
 
     make all-base

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -29,7 +29,7 @@ md5sums=() #generate with 'makepkg -g'
 
 
 build() {
-    rm $srcdir/* -rf
+    rm -rf "$srcdir"/*
     for source in libqrexec agent qrexec policy-agent-extra lib systemd qubes-rpc-config Makefile setup.py version
     do
         # shellcheck disable=SC2154


### PR DESCRIPTION
Should not break CI.

Sidenode: the Arch Linux template I downloaded long ago seem to have not have package registry setup correctly (the files are installed, but the packages like `qubes-vm-qrexec` are not seen as installed to pacman.