### PR TITLE
Add a new get_files method to policy admin api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ install-dom0: all-dom0
 
 	for RPCNAME in \
 		policy.List policy.Get policy.Replace policy.Remove \
-		policy.include.List policy.include.Get policy.include.Replace policy.include.Remove; \
+		policy.include.List policy.include.Get policy.include.Replace \
+		policy.include.Remove policy.GetFiles; \
 	do ln -s /usr/bin/qubes-policy-admin $(DESTDIR)/etc/qubes-rpc/$$RPCNAME; \
 	done
 

--- a/policy.d/90-admin-policy-default.policy
+++ b/policy.d/90-admin-policy-default.policy
@@ -17,6 +17,7 @@
 !include-service policy.include.List     *  include/admin-policy-ro
 !include-service policy.Get              *  include/admin-policy-ro
 !include-service policy.include.Get      *  include/admin-policy-ro
+!include-service policy.GetFiles         *  include/admin-policy-ro
 
 !include-service policy.Replace          *  include/admin-policy-rwx
 !include-service policy.include.Replace  *  include/admin-policy-rwx

--- a/qrexec/client.py
+++ b/qrexec/client.py
@@ -18,7 +18,6 @@
 import pathlib
 import subprocess
 import asyncio
-import os
 
 from .utils import prepare_subprocess_kwds
 
@@ -106,9 +105,6 @@ def make_command(dest, rpcname, arg):
     if VERSION == "dom0" and dest == "dom0":
         # Invoke qubes-rpc-multiplexer directly. This will work for non-socket
         # services only.
-        assert (
-            os.getuid() == 0
-        ), "you need to run as root for local QubesRPC calls"
         return [RPC_MULTIPLEXER, rpcname, "dom0"]
 
     if VERSION == "dom0":

--- a/qrexec/policy/admin.py
+++ b/qrexec/policy/admin.py
@@ -24,7 +24,7 @@ import fcntl
 import os
 import hashlib
 
-from .parser import ValidateParser
+from .parser import ValidateParser, FilePolicy, get_invalid_characters
 from ..exc import PolicySyntaxError
 from .. import RPCNAME_ALLOWED_CHARSET
 
@@ -224,6 +224,36 @@ class PolicyAdmin:
         self._validate(path, None)
 
         path.unlink()
+
+    # List files
+
+    @method("policy.GetFiles", no_payload=True)
+    def policy_get_files(self, arg):
+        if not isinstance(arg, str):
+            raise PolicyAdminException('Service cannot be empty.')
+        invalid_chars = get_invalid_characters(arg, disallowed="+")
+        if invalid_chars:
+            raise PolicyAdminException(
+                "Service {!r} contains invalid characters: {!r}".format(
+                    arg, invalid_chars))
+
+        service = arg
+
+        policy = FilePolicy(policy_path=self.policy_path)
+        rules = policy.find_rules_for_service(service)
+
+        file_list = []
+        for rule in rules:
+            try:
+                rule.filepath.relative_to(self.policy_path)
+            except ValueError:
+                path_to_append = str(rule.filepath)
+            else:
+                path_to_append = rule.filepath.stem
+            if path_to_append not in file_list:
+                file_list.append(path_to_append)
+
+        return ("\n".join(file_list) + "\n").encode('utf-8')
 
     # helpers
 

--- a/qrexec/policy/admin.py
+++ b/qrexec/policy/admin.py
@@ -229,7 +229,7 @@ class PolicyAdmin:
 
     @method("policy.GetFiles", no_payload=True)
     def policy_get_files(self, arg):
-        if not isinstance(arg, str):
+        if not isinstance(arg, str) or not arg:
             raise PolicyAdminException('Service cannot be empty.')
         invalid_chars = get_invalid_characters(arg, disallowed="+")
         if invalid_chars:

--- a/qrexec/policy/admin.py
+++ b/qrexec/policy/admin.py
@@ -253,7 +253,7 @@ class PolicyAdmin:
             if path_to_append not in file_list:
                 file_list.append(path_to_append)
 
-        return ("\n".join(file_list) + "\n").encode('utf-8')
+        return ("".join("{}\n".format(f) for f in file_list)).encode('utf-8')
 
     # helpers
 

--- a/qrexec/policy/admin_client.py
+++ b/qrexec/policy/admin_client.py
@@ -66,7 +66,8 @@ class PolicyClient:
         self.call("policy.Remove", name, token)
 
     def policy_get_files(self, name: str):
-        return self.call("policy.GetFiles", name).rstrip("\n").split("\n")
+        result = self.call("policy.GetFiles", name)
+        return [] if result == "" else result.rstrip("\n").split("\n")
 
     @staticmethod
     def call(service_name, arg=None, payload=""):

--- a/qrexec/policy/admin_client.py
+++ b/qrexec/policy/admin_client.py
@@ -65,6 +65,9 @@ class PolicyClient:
     def policy_include_remove(self, name: str, token="any"):
         self.call("policy.Remove", name, token)
 
+    def policy_get_files(self, name: str):
+        return self.call("policy.GetFiles", name).rstrip("\n").split("\n")
+
     @staticmethod
     def call(service_name, arg=None, payload=""):
         return call("dom0", service_name, arg, input=payload)

--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -895,6 +895,9 @@ class Deny(ActionType):
     def __repr__(self):
         return "<{}>".format(type(self).__name__)
 
+    def __str__(self):
+        return "deny"
+
     def evaluate(self, request):
         """
         Raises:
@@ -930,6 +933,14 @@ class Allow(ActionType):
         return "<{} target={!r} user={!r}>".format(
             type(self).__name__, self.target, self.user
         )
+
+    def __str__(self):
+        return_str = "allow"
+        if self.target:
+            return_str += f" {self.target}"
+        if self.user:
+            return_str += f" {self.user}"
+        return return_str
 
     def evaluate(self, request):
         """
@@ -1008,6 +1019,16 @@ class Ask(ActionType):
         return "<{} target={!r} default_target={!r} user={!r}>".format(
             type(self).__name__, self.target, self.default_target, self.user
         )
+
+    def __str__(self):
+        return_str = "ask"
+        if self.target:
+            return_str += f" {self.target}"
+        if self.default_target:
+            return_str += f" {self.default_target}"
+        if self.user:
+            return_str += f" {self.user}"
+        return return_str
 
     def evaluate(self, request):
         """
@@ -1190,6 +1211,15 @@ class Rule:
                 self.action,
             )
         )
+
+    def __str__(self):
+        return_str = f"{self.service}\t"
+        if self.argument:
+            return_str += f'{self.argument}\t'
+        else:
+            return_str += '*\t'
+        return_str += f'{self.source}\t{self.target}\t{str(self.action)}'
+        return return_str
 
     @classmethod
     def from_line(cls, policy, line, *, filepath, lineno):

--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -937,9 +937,9 @@ class Allow(ActionType):
     def __str__(self):
         return_str = "allow"
         if self.target:
-            return_str += f" {self.target}"
+            return_str += f" target={self.target}"
         if self.user:
-            return_str += f" {self.user}"
+            return_str += f" user={self.user}"
         return return_str
 
     def evaluate(self, request):
@@ -1023,11 +1023,11 @@ class Ask(ActionType):
     def __str__(self):
         return_str = "ask"
         if self.target:
-            return_str += f" {self.target}"
+            return_str += f" target={self.target}"
         if self.default_target:
-            return_str += f" {self.default_target}"
+            return_str += f" default_target={self.default_target}"
         if self.user:
-            return_str += f" {self.user}"
+            return_str += f" user={self.user}"
         return return_str
 
     def evaluate(self, request):

--- a/qrexec/policy/parser_compat.py
+++ b/qrexec/policy/parser_compat.py
@@ -198,8 +198,10 @@ class Compat40Loader(Compat40Parser):
         ...         subparser.execute(filepath=filepath, lineno=lineno)
     """
 
-    def __init__(self, *, legacy_path=POLICYPATH_OLD, **kwds):
+    def __init__(self, *, legacy_path=None, **kwds):
         super().__init__(**kwds)
+        if legacy_path is None:
+            legacy_path = POLICYPATH_OLD
         self.legacy_path = pathlib.Path(legacy_path)
 
     def resolve_path(self, included_path):
@@ -211,8 +213,8 @@ class Compat40Loader(Compat40Parser):
         yield from walk_compat_files(self.legacy_path)
 
 
-class TestCompat40Loader(Compat40Loader, parser.TestLoader):
-    """Used for tests. See :py:class:`qrexec.policy.parser.TestPolicy`."""
+class TestCompat40Loader(Compat40Loader, parser.StringLoader):
+    """Used for tests. See :py:class:`qrexec.policy.parser.StringPolicy`."""
 
     def walk_includes(self):
         """"""

--- a/qrexec/tests/policy_admin.py
+++ b/qrexec/tests/policy_admin.py
@@ -197,3 +197,13 @@ def test_api_get_files(policy_dir, api):
             assert api.handle_request(
                 "policy.GetFiles", "third.service", b"") == \
                    f"{other_dir / 'third.service'}\nfile2\n".encode('utf-8')
+
+    with pytest.raises(
+        PolicyAdminException, match="Service cannot be empty"
+    ):
+        api.handle_request("policy.GetFiles", "", b"")
+
+    with pytest.raises(
+        PolicyAdminException, match="contains invalid characters"
+    ):
+        api.handle_request("policy.GetFiles", "service+param", b"")

--- a/qrexec/tests/policy_admin.py
+++ b/qrexec/tests/policy_admin.py
@@ -169,3 +169,31 @@ def test_api_remove_validate(policy_dir, api):
         PolicyAdminException, match="including a file that will be removed"
     ):
         api.handle_request("policy.include.Remove", "inc", b"any")
+
+
+def test_api_get_files(policy_dir, api):
+    (policy_dir / "file1.policy").write_text("test.service * $any dom0 deny\n"
+                                             "test.service * $any $any allow")
+    (policy_dir / "file2.policy").write_text("other.service * dom0 dom0 allow\n"
+                                             "third.service * $any $any deny")
+
+    assert api.handle_request(
+        "policy.GetFiles", "test.service", b"") == b"file1\n"
+    assert api.handle_request(
+        "policy.GetFiles", "other.service", b"") == b"file2\n"
+
+    # files from outside normal policy directory should be listed as
+    # complete path
+    with tempfile.TemporaryDirectory() as other_dir_name:
+        (policy_dir / 'compat.policy').write_text('!compat-4.0')
+        other_dir = Path(other_dir_name)
+
+        from unittest import mock
+        with mock.patch("qrexec.policy.parser_compat.POLICYPATH_OLD", other_dir):
+            (other_dir / "third.service").write_text(
+                "dom0 dom0 allow\n"
+                "@anyvm @anyvm deny")
+
+            assert api.handle_request(
+                "policy.GetFiles", "third.service", b"") == \
+                   f"{other_dir / 'third.service'}\nfile2\n".encode('utf-8')

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -1016,7 +1016,7 @@ class TC_11_Rule_service(unittest.TestCase):
 # class TC_20_Policy(qubes.tests.QubesTestCase):
 class TC_20_Policy(unittest.TestCase):
     def test_000_load(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
 * * test-vm1 test-vm2 allow
 
@@ -1034,7 +1034,7 @@ class TC_20_Policy(unittest.TestCase):
         self.assertIsInstance(policy.rules[0].action, parser.Action.allow.value)
 
     def test_002_include(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy={
                 "__main__": """\
                 * * test-vm1 test-vm2 allow
@@ -1068,7 +1068,7 @@ class TC_20_Policy(unittest.TestCase):
         self.assertEqual(policy.rules[2].lineno, 3)
 
     def test_003_include_service(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy={
                 "__main__": """\
                 !include-service * * new-syntax
@@ -1099,7 +1099,7 @@ class TC_20_Policy(unittest.TestCase):
         self.assertEqual(policy.rules[3].action.default_target, "@dispvm")
 
     def test_010_find_rule(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 test-vm2 allow
             * * test-vm1 @anyvm ask
@@ -1158,7 +1158,7 @@ class TC_20_Policy(unittest.TestCase):
             policy.find_matching_rule(_req("test-standalone", "@default"))
 
     def test_020_collect_targets_for_ask(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 test-vm2 allow
             * * test-vm1 @anyvm ask
@@ -1343,7 +1343,7 @@ class TC_30_Resolution(unittest.TestCase):
 
 class TC_40_evaluate(unittest.TestCase):
     def setUp(self):
-        self.policy = parser.TestPolicy(
+        self.policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 test-vm2 allow
             * * test-vm1 @default allow target=test-vm2
@@ -1354,7 +1354,7 @@ class TC_40_evaluate(unittest.TestCase):
         )
 
     def test_000_deny(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * @anyvm @anyvm deny"""
         )
@@ -1363,7 +1363,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertTrue(e.exception.notify)
 
     def test_001_deny_no_notify(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * @anyvm @anyvm deny notify=no"""
         )
@@ -1372,7 +1372,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertFalse(e.exception.notify)
 
     def test_030_eval_simple(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 test-vm2 allow"""
         )
@@ -1403,7 +1403,7 @@ class TC_40_evaluate(unittest.TestCase):
 
     def test_032_eval_no_autostart(self):
         # test-vm2 is running, test-vm3 is halted
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 test-vm2 allow autostart=no
             * * test-vm1 test-vm3 allow autostart=no"""
@@ -1460,7 +1460,7 @@ class TC_40_evaluate(unittest.TestCase):
         )
 
     def test_042_eval_ask_no_targets(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @default ask"""
         )
@@ -1468,7 +1468,7 @@ class TC_40_evaluate(unittest.TestCase):
             policy.evaluate(_req("test-vm3", "@default"))
 
     def test_043_eval_ask_no_autostart(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 @anyvm ask"""
         )
@@ -1489,7 +1489,7 @@ class TC_40_evaluate(unittest.TestCase):
             ],
         )
 
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm1 @anyvm ask autostart=no"""
         )
@@ -1498,7 +1498,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertCountEqual(resolution.targets_for_ask, ["test-vm2"])
 
     def test_050_eval_resolve_dispvm(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @dispvm allow"""
         )
@@ -1510,7 +1510,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.request.target, "@dispvm")
 
     def test_051_eval_resolve_dispvm_fail(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-no-dvm @dispvm allow"""
         )
@@ -1518,7 +1518,7 @@ class TC_40_evaluate(unittest.TestCase):
             policy.evaluate(_req("test-no-dvm", "@dispvm"))
 
     def test_052_eval_invalid_override_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @anyvm allow target=no-such-vm"""
         )
@@ -1526,7 +1526,7 @@ class TC_40_evaluate(unittest.TestCase):
             policy.evaluate(_req("test-vm3", "@default"))
 
     def test_053_eval_resolve_dispvm_from_any(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * @anyvm @dispvm allow"""
         )
@@ -1538,7 +1538,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.request.target, "@dispvm")
 
     def test_054_eval_resolve_dispvm_from_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * @anyvm @anyvm allow target=@dispvm"""
         )
@@ -1550,7 +1550,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.request.target, "test-vm1")
 
     def test_055_eval_resolve_dispvm_from_default_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * @anyvm @anyvm ask default_target=@dispvm
             * * @anyvm @dispvm ask"""
@@ -1564,7 +1564,7 @@ class TC_40_evaluate(unittest.TestCase):
 
     @unittest.expectedFailure
     def test_060_eval_to_dom0(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @adminvm allow"""
         )
@@ -1576,7 +1576,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.request.target, "dom0")
 
     def test_061_eval_to_dom0_keyword(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @adminvm allow"""
         )
@@ -1588,7 +1588,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.request.target, "@adminvm")
 
     def test_070_eval_to_dom0_ask_default_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 dom0 ask default_target=dom0"""
         )
@@ -1601,7 +1601,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.targets_for_ask, ["dom0"])
 
     def test_071_eval_to_dom0_ask_default_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 dom0 ask default_target=@adminvm"""
         )
@@ -1614,7 +1614,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.targets_for_ask, ["dom0"])
 
     def test_072_eval_to_dom0_ask_default_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @adminvm ask default_target=dom0"""
         )
@@ -1627,7 +1627,7 @@ class TC_40_evaluate(unittest.TestCase):
         self.assertEqual(resolution.targets_for_ask, ["dom0"])
 
     def test_073_eval_to_dom0_ask_default_target(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy="""\
             * * test-vm3 @adminvm ask default_target=@adminvm"""
         )
@@ -2103,7 +2103,7 @@ class TC_50_Misc(unittest.TestCase):
 
 class TC_90_Compat40(unittest.TestCase):
     def test_001_loader(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy={"__main__": "!compat-4.0"},
             policy_compat={"test.Allow": "$anyvm $anyvm allow"},
         )
@@ -2118,7 +2118,7 @@ class TC_90_Compat40(unittest.TestCase):
         )
 
     def test_100_implicit_deny(self):
-        policy = parser.TestPolicy(
+        policy = parser.StringPolicy(
             policy={
                 "__main__": """
                 test.AllowBefore    * @anyvm @anyvm allow

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -734,6 +734,19 @@ class TC_10_Rule(unittest.TestCase):
             )
         )
 
+    def test_060_serialization(self):
+        lines = ["test.Service\t+argument\t@anyvm\t@anyvm\tallow",
+                 "test.Service\t+argument\t@anyvm\t@anyvm\task",
+                 "test.Service\t+argument\t@anyvm\t@anyvm\tdeny",
+                 "test.Service\t*\t@anyvm\t@anyvm\tdeny",
+                 "test.Service\t+argument\t@anyvm\t@dispvm:default-dvm\tallow",
+                 "test.Service\t+argument\t@tag:tag1\t@type:AppVM\task target=test-vm2 user=user",
+                 "test.Service\t+argument\t@anyvm\t@anyvm\tallow target=@adminvm"]
+
+        for line in lines:
+            rule = parser.Rule.from_line(
+                None, line, filepath="filename", lineno=12)
+            assert str(rule) == line
 
 #   def test_070_expand_override_target(self):
 #       line = parser.Rule.from_line(None,

--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -108,6 +108,7 @@ rm -f %{name}-%{version}
 %{_sysconfdir}/qubes-rpc/qubes.WaitForSession
 %{_sysconfdir}/qubes-rpc/policy.List
 %{_sysconfdir}/qubes-rpc/policy.Get
+%{_sysconfdir}/qubes-rpc/policy.GetFiles
 %{_sysconfdir}/qubes-rpc/policy.Replace
 %{_sysconfdir}/qubes-rpc/policy.Remove
 %{_sysconfdir}/qubes-rpc/policy.include.List


### PR DESCRIPTION
Needed for global configuration tool.
Also removed requirement for root for performing policy queries, added str representation for policy rules and renamed TestPolicyLoaders to StringPolicyLoaders to be able to use them more flexibly.