### PR TITLE
Fix incorrect ownership of policy dirs

### DIFF
--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -93,8 +93,8 @@ rm -f %{name}-%{version}
 %{_sbindir}/qrexec-daemon
 /usr/lib/qubes/qrexec-client
 
-%dir %{_sysconfdir}/qubes/policy.d
-%dir %{_sysconfdir}/qubes/policy.d/include
+%dir %attr(0775,root,qubes) %{_sysconfdir}/qubes/policy.d
+%dir %attr(0775,root,qubes) %{_sysconfdir}/qubes/policy.d/include
 %{_sysconfdir}/qubes/policy.d/README
 %{_sysconfdir}/qubes/policy.d/35-compat.policy
 %{_sysconfdir}/qubes/policy.d/90-admin-policy-default.policy


### PR DESCRIPTION
Now it's owned by qubes group, not root group,
to enable editing policy by normal system tools.

fixes QubesOS/qubes-issues#7604