### PR TITLE
Prefix data support

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -266,6 +266,9 @@ static int handle_new_process_common(
     req.sigchld = &sigchld;
     req.sigusr1 = &sigusr1;
 
+    req.prefix_data.data = NULL;
+    req.prefix_data.len = 0;
+
     exit_code = process_io(&req);
 
     if (type == MSG_EXEC_CMDLINE)
@@ -303,7 +306,8 @@ pid_t handle_new_process(int type, int connect_domain, int connect_port,
 /* Returns exit code of remote process */
 int handle_data_client(
     int type, int connect_domain, int connect_port,
-    int stdin_fd, int stdout_fd, int stderr_fd, int buffer_size, pid_t pid)
+    int stdin_fd, int stdout_fd, int stderr_fd, int buffer_size, pid_t pid,
+    const char *extra_data)
 {
     int exit_code;
     int data_protocol_version;
@@ -345,6 +349,14 @@ int handle_data_client(
 
     req.sigchld = &sigchld;
     req.sigusr1 = &sigusr1;
+
+    if (extra_data) {
+        req.prefix_data.data = extra_data;
+        req.prefix_data.len = strlen(extra_data);
+    } else {
+        req.prefix_data.data = NULL;
+        req.prefix_data.len = 0;
+    }
 
     exit_code = process_io(&req);
     libvchan_close(data_vchan);

--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -180,7 +180,7 @@ static int handle_new_process_common(
     int exit_code;
     int data_protocol_version;
     struct buffer stdin_buf;
-    struct process_io_request req;
+    struct process_io_request req = { 0 };
     int stdin_fd, stdout_fd, stderr_fd;
     pid_t pid;
 
@@ -308,7 +308,7 @@ int handle_data_client(
     int exit_code;
     int data_protocol_version;
     libvchan_t *data_vchan;
-    struct process_io_request req;
+    struct process_io_request req = { 0 };
     struct buffer stdin_buf;
 
     assert(type == MSG_SERVICE_CONNECT);

--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -46,7 +46,7 @@ pid_t handle_new_process(int type,
 int handle_data_client(int type,
         int connect_domain, int connect_port,
         int stdin_fd, int stdout_fd, int stderr_fd,
-        int buffer_size, pid_t pid);
+        int buffer_size, pid_t pid, const char *extra_data);
 
 
 struct qrexec_cmd_info {

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -103,10 +103,11 @@ static struct option longopts[] = {
     { "no-filter-escape-chars-stdout", no_argument, 0, opt_no_filter_stdout},
     { "no-filter-escape-chars-stderr", no_argument, 0, opt_no_filter_stderr},
     { "agent-socket", required_argument, 0, 'a'},
+    { "help", no_argument, 0, 'h' },
     { NULL, 0, 0, 0},
 };
 
-_Noreturn static void usage(const char *argv0) {
+_Noreturn static void usage(const char *argv0, int status) {
     fprintf(stderr,
             "usage: %s [options] target_vmname program_ident [local_program [local program arguments]]\n",
             argv0);
@@ -118,7 +119,8 @@ _Noreturn static void usage(const char *argv0) {
     fprintf(stderr, "  --no-filter-escape-chars-stderr - opposite to --filter-escape-chars-stderr\n");
     fprintf(stderr, "  --agent-socket=PATH - path to connect to, default: %s\n",
             QREXEC_AGENT_TRIGGER_PATH);
-    exit(2);
+    fprintf(stderr, "  -h, --help - print this message\n");
+    exit(status);
 }
 
 int main(int argc, char **argv)
@@ -145,7 +147,7 @@ int main(int argc, char **argv)
     signal(SIGPIPE, SIG_IGN);
 
     while (1) {
-        opt = getopt_long(argc, argv, "+tTa:", longopts, NULL);
+        opt = getopt_long(argc, argv, "+tTa:h", longopts, NULL);
         if (opt == -1)
             break;
         switch (opt) {
@@ -175,6 +177,8 @@ int main(int argc, char **argv)
             case 'T':
                 replace_chars_stderr = 1;
                 break;
+            case 'h':
+                usage(argv[0], 0);
             case opt_no_filter_stdout:
                 replace_chars_stdout = 0;
                 break;
@@ -188,12 +192,12 @@ int main(int argc, char **argv)
                 }
                 break;
             case '?':
-                usage(argv[0]);
+                usage(argv[0], 2);
         }
     }
 
     if (argc - optind < 2) {
-        usage(argv[0]);
+        usage(argv[0], 2);
     }
     if (argc - optind > 2) {
         start_local_process = 1;

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -32,6 +32,7 @@
 #include "libqrexec-utils.h"
 #include "qrexec.h"
 #include "qrexec-agent.h"
+#include <err.h>
 
 const bool qrexec_is_fork_server = false;
 
@@ -272,10 +273,10 @@ int main(int argc, char **argv)
                     }
                 }
 
-                dup2(inpipe[0], 0);
-                dup2(outpipe[1], 1);
-                close(inpipe[0]);
-                close(outpipe[1]);
+                if (dup2(inpipe[0], 0) != 0 || dup2(outpipe[1], 1) != 1)
+                    err(1, "dup2()");
+                if (close(inpipe[0]) || close(outpipe[1]))
+                    err(1, "close()");
 
                 abs_exec_path = strdup(argv[optind + 2]);
                 argv[optind + 2] = get_program_name(argv[optind + 2]);

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -265,11 +265,11 @@ int main(int argc, char **argv)
                 for (i = 0; i < 3; i++) {
                     if (i != 2 || getenv("PASS_LOCAL_STDERR")) {
                         char *env;
-                        if (asprintf(&env, "SAVED_FD_%d=%d", i, dup(i)) < 0) {
+                        int dup_fd = dup(i);
+                        if (dup_fd < 0 || asprintf(&env, "SAVED_FD_%d=%d", i, dup_fd) < 0 || putenv(env)) {
                             PERROR("prepare SAVED_FD_");
                             exit(1);
                         }
-                        putenv(env);
                     }
                 }
 

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -356,7 +356,7 @@ static void send_service_connect(int s, char *conn_ident,
 
 static void select_loop(libvchan_t *vchan, int data_protocol_version, struct buffer *stdin_buf)
 {
-    struct process_io_request req;
+    struct process_io_request req = { 0 };
     int exit_code;
 
     req.vchan = vchan;
@@ -518,7 +518,7 @@ int main(int argc, char **argv)
     int connect_existing = 0;
     char *local_cmdline = NULL;
     char *remote_cmdline = NULL;
-    char *request_id;
+    char *request_id = NULL;
     char *src_domain_name = NULL;
     int src_domain_id = 0; /* if not -c given, the process is run in dom0 */
     int connection_timeout = 5;

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -371,6 +371,8 @@ static void select_loop(libvchan_t *vchan, int data_protocol_version, struct buf
     req.data_protocol_version = data_protocol_version;
     req.sigchld = &sigchld;
     req.sigusr1 = NULL;
+    req.prefix_data.data = NULL;
+    req.prefix_data.len = 0;
 
     exit_code = process_io(&req);
     libvchan_close(vchan);

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -193,6 +193,11 @@ int handle_remote_data(
     struct buffer *stdin_buf, int data_protocol_version,
     bool replace_chars_stdout, bool replace_chars_stderr, bool is_service);
 
+struct prefix_data {
+    const char *data;
+    size_t len;
+};
+
 /*
  * Handle data from the specified FD (cannot be -1) and send it over vchan
  * with a given message type (MSG_DATA_STDIN/STDOUT/STDERR).
@@ -205,7 +210,7 @@ int handle_remote_data(
  */
 int handle_input(
     libvchan_t *vchan, int fd, int msg_type,
-    int data_protocol_version);
+    int data_protocol_version, struct prefix_data *data);
 
 int send_exit_code(libvchan_t *vchan, int status);
 
@@ -241,6 +246,7 @@ struct process_io_request {
     volatile sig_atomic_t *sigchld;
     // can be NULL
     volatile sig_atomic_t *sigusr1;
+    struct prefix_data prefix_data;
 };
 
 /*

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -123,6 +123,7 @@ int process_io(const struct process_io_request *req) {
     sigset_t pollmask;
     struct timespec zero_timeout = { 0, 0 };
     struct timespec normal_timeout = { 10, 0 };
+    struct prefix_data empty = { 0, 0 }, prefix = req->prefix_data;
 
     sigemptyset(&pollmask);
     sigaddset(&pollmask, SIGCHLD);
@@ -297,7 +298,7 @@ int process_io(const struct process_io_request *req) {
         if (stdout_fd >= 0 && fds[FD_STDOUT].revents) {
             switch (handle_input(
                         vchan, stdout_fd, stdout_msg_type,
-                        data_protocol_version)) {
+                        data_protocol_version, &prefix)) {
                 case REMOTE_ERROR:
                     handle_vchan_error("send(handle_input stdout)");
                     break;
@@ -310,7 +311,7 @@ int process_io(const struct process_io_request *req) {
         if (stderr_fd >= 0 && fds[FD_STDERR].revents) {
             switch (handle_input(
                         vchan, stderr_fd, MSG_DATA_STDERR,
-                        data_protocol_version)) {
+                        data_protocol_version, &empty)) {
                 case REMOTE_ERROR:
                     handle_vchan_error("send(handle_input stderr)");
                     break;


### PR DESCRIPTION
This allows passing a prefix data argument to qrexec-client-vm.  Prefix
data is sent before the data on stdin, which is useful for e.g.
requesting armored or binary OpenPGP signatures.