### PR TITLE
Enable `-D_FORTIFY_SOURCE=3`

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -8,7 +8,7 @@ HAVE_PAM_APPL = $(or $(and $(wildcard /usr/include/security/pam_appl.h),1),)
 override os := $(shell lsb_release -is)
 override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+   -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
 	-D_GNU_SOURCE $(CFLAGS) $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM)
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS=-lqrexec-utils $(shell pkg-config --libs $(VCHAN_PKG)) $(if $(HAVE_PAM_APPL),-lpam,)

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -2,7 +2,7 @@ CC ?=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 override QUBES_CFLAGS:=-I../libqrexec -g -O2 -Wall -Wextra -Werror -pie -fPIC \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+   -D_FORTIFY_SOURCE=3 -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
    -D_GNU_SOURCE $(CFLAGS)
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS += $(shell pkg-config --libs $(VCHAN_PKG)) -lqrexec-utils

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -2,7 +2,7 @@ CC=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+   -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
    -D_GNU_SOURCE $(CFLAGS)
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
 


### PR DESCRIPTION
This improves `_FORTIFY_SOURCE` coverage on compilers that support it.