### PR TITLE
Do not exit successfully if local process failed

### DIFF
--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -340,7 +340,7 @@ int process_io(const struct process_io_request *req) {
             PERROR("waitpid");
     }
 
-    if (!is_service)
+    if (!is_service && remote_status)
         return remote_status;
     return local_pid ? local_status : 0;
 }


### PR DESCRIPTION
If the local process failed, the exit code must be non-zero.  Otherwise callers will believe that the local process succeeded when it did not. In the case of qvm-move and qvm-move-to-vm, the result is that the shell script wrapper deletes the source files even though some of them were not transferred to the destination qube.  This destroys user data.

Reported-by: Marta Marczykowska-Górecka <marmarta@invisiblethingslab.com>
Fixes: QubesOS/qubes-issues#7905