### PR TITLE
Allow specifying a username in service config

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -10,7 +10,7 @@ override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
 	-D_GNU_SOURCE $(CFLAGS) $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM) \
-	-Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
+	-Wstrict-prototypes -Wold-style-definition -Wmissing-declarations -Werror=vla
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS=-lqrexec-utils $(shell pkg-config --libs $(VCHAN_PKG)) $(if $(HAVE_PAM_APPL),-lpam,)
 

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -572,7 +572,7 @@ static int wait_for_session_maybe(char *cmdline) {
             dup2(stdin_pipe[0], 0);
             exec_wait_for_session(cmd->source_domain);
             PERROR("exec");
-            exit(1);
+            _exit(1);
         case -1:
             PERROR("fork");
             goto out;

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -61,6 +61,7 @@ struct waiting_request {
     int connect_port;
     int padding;
     char *cmdline;
+    struct qrexec_parsed_command *cmd;
 };
 
 /*  */
@@ -81,7 +82,9 @@ static int meminfo_write_started = 0;
 static const char *agent_trigger_path = QREXEC_AGENT_TRIGGER_PATH;
 static const char *fork_server_path = QREXEC_FORK_SERVER_SOCKET;
 
-static void handle_server_exec_request_do(int type, int connect_domain, int connect_port, char *cmdline);
+static void handle_server_exec_request_do(int type, int connect_domain, int connect_port,
+                                          struct qrexec_parsed_command *cmd,
+                                          char *cmdline);
 
 const bool qrexec_is_fork_server = false;
 
@@ -427,7 +430,7 @@ static void wake_meminfo_writer(void)
 }
 
 static int try_fork_server(int type, int connect_domain, int connect_port,
-        char *cmdline, size_t cmdline_len) {
+        char *cmdline, size_t cmdline_len, const char *username) {
     char *colon;
     char *fork_server_socket_path;
     int s = -1;
@@ -438,16 +441,9 @@ static int try_fork_server(int type, int connect_domain, int connect_port,
 
     if (cmdline_len > MAX_QREXEC_CMD_LEN)
         return -1;
-    char *username = malloc(cmdline_len);
-    if (!username) {
-        PERROR("Memory allocation failed");
-        return -1;
-    }
-    memcpy(username, cmdline, cmdline_len);
-    colon = strchr(username, ':');
+    colon = strchr(cmdline, ':');
     if (!colon)
         goto fail;
-    *colon = '\0';
 
     if (asprintf(&fork_server_socket_path, fork_server_path, username) < 0) {
         LOG(ERROR, "Memory allocation failed");
@@ -475,7 +471,7 @@ static int try_fork_server(int type, int connect_domain, int connect_port,
     info.type = type;
     info.connect_domain = connect_domain;
     info.connect_port = connect_port;
-    size_t username_len = strlen(username);
+    size_t username_len = (size_t)(colon - cmdline);
     assert(cmdline_len <= INT_MAX);
     assert(cmdline_len > username_len);
     info.cmdline_len = (int)(cmdline_len - (username_len + 1));
@@ -488,12 +484,10 @@ static int try_fork_server(int type, int connect_domain, int connect_port,
         goto fail;
     }
 
-    free(username);
     return s;
 fail:
     if (s >= 0)
         close(s);
-    free(username);
     return -1;
 }
 
@@ -523,43 +517,19 @@ static void register_vchan_connection(pid_t pid, int fd, int domain, int port)
  *  only after session is started)
  *  - 0 - waiting is not needed, caller may proceed with request immediately
  */
-static int wait_for_session_maybe(char *cmdline) {
-    struct qrexec_parsed_command *cmd;
+static bool wait_for_session_maybe(struct qrexec_parsed_command *cmd) {
     int stdin_pipe[2];
-    int wait_for_session = 0;
-    int ret = 0;
     sigset_t sigmask;
-
-    cmd = parse_qubes_rpc_command(cmdline, true);
-    if (!cmd)
-        /* error parsing the command, this will be properly reported later */
-        return 0;
-
-    /* "nogui:" prefix has priority - do not wait for session */
-    if (cmd->nogui)
-        goto out;
-
-    /* wait for session only for service requests */
-    if (!cmd->service_descriptor)
-        goto out;
-
-    /* load service config - if it fails, use initial value */
-    load_service_config(cmd, &wait_for_session);
-
-    if (!wait_for_session)
-        /* setting not set, or set to 0 */
-        goto out;
 
     /* ok, now we know that service is configured to wait for session */
     if (wait_for_session_pid != -1) {
         /* we're already waiting */
-        ret = 1;
-        goto out;
+        return true;
     }
 
     if (pipe(stdin_pipe) == -1) {
         PERROR("pipe for wait-for-session");
-        goto out;
+        return false;
     }
     /* start waiting process */
     wait_for_session_pid = fork();
@@ -575,7 +545,7 @@ static int wait_for_session_maybe(char *cmdline) {
             _exit(1);
         case -1:
             PERROR("fork");
-            goto out;
+            return false;
         default:
             close(stdin_pipe[0]);
             if (write(stdin_pipe[1], cmd->username, strlen(cmd->username)) == -1)
@@ -586,11 +556,7 @@ static int wait_for_session_maybe(char *cmdline) {
     }
 
     /* qubes.WaitForSession started, postpone request until it report back */
-    ret = 1;
-
-out:
-    destroy_qrexec_parsed_command(cmd);
-    return ret;
+    return true;
 }
 
 
@@ -598,7 +564,8 @@ out:
 static void handle_server_exec_request_init(struct msg_header *hdr)
 {
     struct exec_params params;
-    if (hdr->len < sizeof(params))
+    struct qrexec_parsed_command *cmd;
+    if (hdr->len <= sizeof(params))
         abort();
     size_t buf_len = hdr->len - sizeof(params);
     if (buf_len > INT_MAX)
@@ -614,29 +581,57 @@ static void handle_server_exec_request_init(struct msg_header *hdr)
 
     buf[buf_len-1] = 0;
 
-    if (hdr->type != MSG_SERVICE_CONNECT && wait_for_session_maybe(buf)) {
-        /* waiting for session, postpone actual call */
-        int slot_index;
-        for (slot_index = 0; slot_index < MAX_FDS; slot_index++)
-            if (!requests_waiting_for_session[slot_index].cmdline)
-                break;
-        if (slot_index == MAX_FDS) {
-            /* no free slots */
-            LOG(WARNING, "No free slots for waiting for GUI session, continuing!");
-        } else {
-            requests_waiting_for_session[slot_index].type = hdr->type;
-            requests_waiting_for_session[slot_index].connect_domain = params.connect_domain;
-            requests_waiting_for_session[slot_index].connect_port = params.connect_port;
-            requests_waiting_for_session[slot_index].cmdline = strdup(buf);
-            /* nothing to do now, when we get GUI session, we'll continue */
+    if (hdr->type == MSG_SERVICE_CONNECT) {
+        cmd = NULL;
+    } else {
+        cmd = parse_qubes_rpc_command(buf, true);
+        if (cmd == NULL) {
+            LOG(ERROR, "Could not parse command line: %s", buf);
             return;
+        }
+
+        /* load service config only for service requests */
+        if (cmd->service_descriptor) {
+            int wait_for_session = 0;
+
+            if (load_service_config(cmd, &wait_for_session) < 0) {
+                LOG(ERROR, "Could not load config for command %s", buf);
+                return;
+            }
+
+            /* "nogui:" prefix has priority */
+            if (!cmd->nogui && wait_for_session && wait_for_session_maybe(cmd)) {
+                /* waiting for session, postpone actual call */
+                int slot_index;
+                for (slot_index = 0; slot_index < MAX_FDS; slot_index++)
+                    if (!requests_waiting_for_session[slot_index].cmdline)
+                        break;
+                if (slot_index == MAX_FDS) {
+                    /* no free slots */
+                    LOG(WARNING, "No free slots for waiting for GUI session, continuing!");
+                } else {
+                    requests_waiting_for_session[slot_index].type = hdr->type;
+                    requests_waiting_for_session[slot_index].connect_domain = params.connect_domain;
+                    requests_waiting_for_session[slot_index].connect_port = params.connect_port;
+                    requests_waiting_for_session[slot_index].cmdline = buf;
+                    requests_waiting_for_session[slot_index].cmd = cmd;
+                    /* nothing to do now, when we get GUI session, we'll continue */
+                    return;
+                }
+            }
         }
     }
 
-    handle_server_exec_request_do(hdr->type, params.connect_domain, params.connect_port, buf);
+    handle_server_exec_request_do(hdr->type, params.connect_domain, params.connect_port, cmd, buf);
+    destroy_qrexec_parsed_command(cmd);
+    free(buf);
 }
 
-static void handle_server_exec_request_do(int type, int connect_domain, int connect_port, char *cmdline) {
+static void handle_server_exec_request_do(int type,
+                                          int connect_domain,
+                                          int connect_port,
+                                          struct qrexec_parsed_command *cmd,
+                                          char *cmdline) {
     int client_fd;
     pid_t child_agent;
     size_t cmdline_len = strlen(cmdline) + 1; // size of cmdline, including \0 at the end
@@ -645,32 +640,18 @@ static void handle_server_exec_request_do(int type, int connect_domain, int conn
         .connect_port = connect_port,
     };
 
-    if ((type == MSG_EXEC_CMDLINE || type == MSG_JUST_EXEC) &&
-            !strstr(cmdline, ":nogui:")) {
-        int child_socket;
+    if (type == MSG_SERVICE_CONNECT) {
+        if (sscanf(cmdline, "SOCKET%d", &client_fd) != 1)
+            goto bad_ident;
 
-        child_socket = try_fork_server(type,
-                params.connect_domain, params.connect_port,
-                cmdline, cmdline_len);
-        if (child_socket >= 0) {
-            register_vchan_connection(-1, child_socket,
-                    params.connect_domain, params.connect_port);
-            return;
-        }
-    }
-
-    if (type == MSG_SERVICE_CONNECT && sscanf(cmdline, "SOCKET%d", &client_fd)) {
         /* FIXME: Maybe add some check if client_fd is really FD to some
          * qrexec-client-vm process; but this data comes from qrexec-daemon
          * (which sends back what it got from us earlier), so it isn't critical.
          */
         if (write(client_fd, &params, sizeof(params)) < 0) {
             /* Do not start polling invalid FD */
-            if (errno == EBADF) {
-                LOG(ERROR, "Got MSG_SERVICE_CONNECT from qrexec-daemon with invalid ident (%s), ignoring",
-                        cmdline);
-                return;
-            }
+            if (errno == EBADF)
+                goto bad_ident;
             /* ignore other errors */
         }
         /* No need to send request_id (buf) - the client don't need it, there
@@ -684,13 +665,29 @@ static void handle_server_exec_request_do(int type, int connect_domain, int conn
         return;
     }
 
+    if (!cmd->nogui) {
+        /* try fork server */
+        int child_socket = try_fork_server(type,
+                params.connect_domain, params.connect_port,
+                cmdline, cmdline_len, cmd->username);
+        if (child_socket >= 0) {
+            register_vchan_connection(-1, child_socket,
+                    params.connect_domain, params.connect_port);
+            return;
+        }
+    }
+
     /* No fork server case */
     child_agent = handle_new_process(type,
             params.connect_domain, params.connect_port,
-            cmdline, cmdline_len);
+            cmd);
 
     register_vchan_connection(child_agent, -1,
             params.connect_domain, params.connect_port);
+    return;
+bad_ident:
+    LOG(ERROR, "Got MSG_SERVICE_CONNECT from qrexec-daemon with invalid ident (%s), ignoring",
+            cmdline);
 }
 
 static void handle_service_refused(struct msg_header *hdr)
@@ -790,7 +787,10 @@ static void reap_children(void)
                         requests_waiting_for_session[id].type,
                         requests_waiting_for_session[id].connect_domain,
                         requests_waiting_for_session[id].connect_port,
+                        requests_waiting_for_session[id].cmd,
                         requests_waiting_for_session[id].cmdline);
+                destroy_qrexec_parsed_command(requests_waiting_for_session[id].cmd);
+                requests_waiting_for_session[id].cmd = NULL;
                 free(requests_waiting_for_session[id].cmdline);
                 requests_waiting_for_session[id].cmdline = NULL;
             }

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -593,10 +593,16 @@ static void handle_server_exec_request_init(struct msg_header *hdr)
         /* load service config only for service requests */
         if (cmd->service_descriptor) {
             int wait_for_session = 0;
+            char *user = NULL;
 
-            if (load_service_config(cmd, &wait_for_session) < 0) {
+            if (load_service_config(cmd, &wait_for_session, &user) < 0) {
                 LOG(ERROR, "Could not load config for command %s", buf);
                 return;
+            }
+
+            if (user != NULL) {
+                free(cmd->username);
+                cmd->username = user;
             }
 
             /* "nogui:" prefix has priority */

--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -42,7 +42,7 @@ extern const bool qrexec_is_fork_server;
 
 pid_t handle_new_process(int type,
         int connect_domain, int connect_port,
-        char *cmdline, size_t cmdline_len);
+        struct qrexec_parsed_command *cmd);
 int handle_data_client(int type,
         int connect_domain, int connect_port,
         int stdin_fd, int stdout_fd, int stderr_fd,
@@ -53,7 +53,7 @@ struct qrexec_cmd_info {
 	int type;
 	int connect_domain;
 	int connect_port;
-	int cmdline_len;
+	unsigned int cmdline_len;
 	char cmdline[];
 };
 

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -90,9 +90,13 @@ static void handle_single_command(int fd, struct qrexec_cmd_info *info) {
         goto fail;
     }
 
+    struct qrexec_parsed_command *cmd = parse_qubes_rpc_command(cmdline, false);
+    if (cmd == NULL)
+        goto fail;
+
     handle_new_process(info->type, info->connect_domain,
-            info->connect_port,
-            cmdline, cmdline_len);
+                       info->connect_port, cmd);
+    destroy_qrexec_parsed_command(cmd);
 fail:
     free(cmdline);
 }

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -228,7 +228,8 @@ static void wait_for_session_maybe(char *cmdline)
     if (!cmd->service_descriptor)
         goto out;
 
-    load_service_config(cmd, &wait_for_session);
+    char *user = NULL;
+    load_service_config(cmd, &wait_for_session, &user);
     if (!wait_for_session)
         goto out;
 

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS += -O1 -fno-omit-frame-pointer -gline-tables-only \
 		-fsanitize-address-use-after-scope -fsanitize=fuzzer
 endif
 
-_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o
+_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o toml.o
 LIBQREXEC_OBJS = $(patsubst %.o,libqrexec-%.o,$(_LIBQREXEC_OBJS))
 
 FUZZERS = qubesrpc_parse_fuzzer qrexec_remote_fuzzer qrexec_daemon_fuzzer

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -20,7 +20,7 @@ endif
 
 
 all: libqrexec-utils.so
-libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o
+libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o toml.o
 	$(CC) $(LDFLAGS) -Wl,-soname,$@ -o $@ $^ $(VCHANLIBS)
 
 libqrexec-utils.so: libqrexec-utils.so.$(SO_VER)

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -251,10 +251,10 @@ static int find_file(
     }
     return -1;
 }
-
 int load_service_config(const struct qrexec_parsed_command *cmd,
-                        int *wait_for_session) {
+                        int *wait_for_session, char **user) {
     assert(cmd->service_descriptor);
+    assert(*user == NULL);
 
     const char *config_path = getenv("QUBES_RPC_CONFIG_PATH");
     if (!config_path)
@@ -270,38 +270,7 @@ int load_service_config(const struct qrexec_parsed_command *cmd,
     if (ret < 0)
         return 0;
 
-    char config[MAX_CONFIG_SIZE];
-    char *config_iter = config;
-    FILE *config_file;
-    size_t read_count;
-    char *current_line;
-
-    config_file = fopen(config_full_path, "re");
-    if (!config_file) {
-        PERROR("Failed to load %s", config_full_path);
-        return -1;
-    }
-
-    read_count = fread(config, 1, sizeof(config)-1, config_file);
-
-    if (ferror(config_file)) {
-        fclose(config_file);
-        return -1;
-    }
-
-    // config is a text file, should not have \0 inside; but when it has, part
-    // after it will be ignored
-    config[read_count] = 0;
-
-    while ((current_line = strsep(&config_iter, "\n"))) {
-        // ignore comments
-        if (current_line[0] == '#')
-            continue;
-        sscanf(current_line, "wait-for-session=%d", wait_for_session);
-    }
-
-    fclose(config_file);
-    return 1;
+    return qubes_toml_config_parse(config_full_path, wait_for_session, user);
 }
 
 struct qrexec_parsed_command *parse_qubes_rpc_command(

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -281,7 +281,7 @@ int process_io(const struct process_io_request *req);
 
 
 void qrexec_log(int level, int errnoval, const char *file, int line,
-                const char *func, const char *fmt, ...);
+                const char *func, const char *fmt, ...) __attribute__((format(printf, 6, 7)));
 
 void setup_logging(const char *program_name);
 

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -91,7 +91,7 @@ void destroy_qrexec_parsed_command(struct qrexec_parsed_command *cmd);
  *  -1 - other error
  */
 int load_service_config(const struct qrexec_parsed_command *cmd_name,
-                        int *wait_for_session);
+                        int *wait_for_session, char **user);
 
 typedef void (do_exec_t)(const char *cmdline, const char *user);
 void register_exec_func(do_exec_t *func);
@@ -303,6 +303,7 @@ void qrexec_log(int level, int errnoval, const char *file, int line,
                 const char *func, const char *fmt, ...) __attribute__((format(printf, 6, 7)));
 
 void setup_logging(const char *program_name);
+int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user);
 
 /**
  * Make an Admin API call to qubesd.  The returned buffer must be released by

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -83,8 +83,7 @@ struct qrexec_parsed_command *parse_qubes_rpc_command(
     const char *cmdline, bool strip_username);
 void destroy_qrexec_parsed_command(struct qrexec_parsed_command *cmd);
 
-/* Load service configuration, currently only wait-for-session option
- * supported.
+/* Load service configuration.
  *
  * Return:
  *  1  - config successfuly loaded
@@ -117,6 +116,26 @@ int write_stdin(int fd, const char *data, int len, struct buffer *buffer);
 int fork_and_flush_stdin(int fd, struct buffer *buffer);
 
 /**
+ * @brief Execute an already-parsed Qubes RPC command.
+ * @param cmdline Null-terminated command to execute.
+ * @param pid On return, holds the PID of the child process.
+ * @param stdin_fd On return, holds a file descriptor connected to the child's
+ * stdin.
+ * @param stdout_fd On return, holds a file descriptor connected to the child's
+ * stdout.
+ * @param stderr_fd On return, holds a file descriptor connected to the child's
+ * stderr.
+ * @param buffer This buffer will need to be prepended to the child process’s
+ * stdin.
+ * @return 0 if it spawned (or might have spawned) an external process,
+ * nonzero on failure.
+ */
+int execute_parsed_qubes_rpc_command(
+        const struct qrexec_parsed_command *cmd, int *pid, int *stdin_fd,
+        int *stdout_fd, int *stderr_fd, struct buffer *stdin_buffer);
+
+/**
+ * @brief Execute a Qubes RPC command.
  * @param cmdline Null-terminated command to execute.
  * @param pid On return, holds the PID of the child process.
  * @param stdin_fd On return, holds a file descriptor connected to the child's
@@ -130,7 +149,7 @@ int fork_and_flush_stdin(int fd, struct buffer *buffer);
  * @param buffer This buffer will need to be prepended to the child process’s
  * stdin.
  * @return 0 if it spawned (or might have spawned) an external process,
- * a (positive) errno value otherwise.
+ * nonzero on failure.
  */
 int execute_qubes_rpc_command(const char *cmdline, int *pid, int *stdin_fd,
                               int *stdout_fd, int *stderr_fd,

--- a/libqrexec/remote.c
+++ b/libqrexec/remote.c
@@ -128,7 +128,7 @@ int handle_remote_data(
                 /* remote process exited, so there is no sense to send any data
                  * to it */
                 if (hdr.len < sizeof(*status)) {
-                    LOG(ERROR, "MSG_DATA_EXIT_CODE too short: " PRIu32 " < %zu",
+                    LOG(ERROR, "MSG_DATA_EXIT_CODE too short: %u < %zu",
                         hdr.len, sizeof(*status));
                     *status = 255;
                 } else

--- a/libqrexec/toml.c
+++ b/libqrexec/toml.c
@@ -1,0 +1,276 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <limits.h>
+
+#include "libqrexec-utils.h"
+
+// A trivial parser for a subset of TOML
+static bool qubes_isspace(unsigned char c) {
+    return c == ' ' || c == '\t';
+}
+
+enum toml_type {
+    TOML_TYPE_INVALID, // error
+    TOML_TYPE_BOOL,
+    TOML_TYPE_INTEGER,
+    TOML_TYPE_STRING,
+};
+
+union toml_data {
+    char *string; // allocated with malloc()
+    bool boolean;
+    unsigned long long integer;
+};
+
+static enum toml_type parse_toml_value(
+    const char *file,
+    size_t line,
+    unsigned char *value_to_parse,
+    union toml_data *value) {
+    enum toml_type ty = TOML_TYPE_INVALID;
+    char *end = NULL;
+
+    switch (value_to_parse[0]) {
+    case '0':
+        ty = TOML_TYPE_INTEGER;
+        value->integer = 0;
+        end = (char *)(value_to_parse + 1);
+        break;
+    case '1' ... '9':
+        ty = TOML_TYPE_INTEGER;
+        errno = 0;
+        value->integer = strtoull((char *)value_to_parse, &end, 10);
+        if (errno) {
+            PERROR("%s:%zu: strtoull()", file, line);
+            return TOML_TYPE_INVALID;
+        }
+        break;
+    case 't':
+        ty = TOML_TYPE_BOOL;
+        if (strncmp((char *)value_to_parse, "true", 4) == 0) {
+            value->boolean = true;
+            end = (char *)(value_to_parse + 4);
+            break;
+        } else {
+            LOG(ERROR, "%s:%zu: Unexpected unquoted string", file, line);
+            return TOML_TYPE_INVALID;
+        }
+    case 'f':
+        ty = TOML_TYPE_BOOL;
+        if (strncmp((char *)value_to_parse, "false", 5) == 0) {
+            value->boolean = false;
+            end = (char *)(value_to_parse + 5);
+            break;
+        } else {
+            LOG(ERROR, "%s:%zu: Unexpected unquoted string", file, line);
+            return TOML_TYPE_INVALID;
+        }
+    case '"':
+        LOG(ERROR, "%s:%zu: Double-quoted strings not implemented, use single quotes", file, line);
+        return TOML_TYPE_INVALID;
+    case '\'':
+        ty = TOML_TYPE_STRING;
+        if (value_to_parse[1] == '\'' && value_to_parse[2] == '\'') {
+            LOG(ERROR, "%s:%zu: Triple-quoted strings not implemented", file, line);
+            return TOML_TYPE_INVALID;
+        }
+        end = strchr((char *)value_to_parse + 1, '\'');
+        if (end == NULL) {
+            LOG(ERROR, "%s:%zu: Unterminated quoted string", file, line);
+            return TOML_TYPE_INVALID;
+        } else {
+            size_t to_alloc = (size_t)(end - (char *)value_to_parse);
+            value->string = malloc(to_alloc);
+            if (value->string == NULL) {
+                LOG(ERROR, "%s:%zu: Out of memory copying value", file, line);
+                return TOML_TYPE_INVALID;
+            }
+            memcpy(value->string, value_to_parse + 1, to_alloc - 1);
+            value->string[to_alloc - 1] = 0;
+            end++;
+            break;
+        }
+    default:
+        if (value_to_parse[0] >= ' ' && value_to_parse[0] <= '~') {
+            LOG(ERROR, "%s:%zu: Unsupported start of value: '%c'", file, line, value_to_parse[0]);
+        } else {
+            LOG(ERROR, "%s:%zu: Unsupproted byte at start of value: %d", file, line, value_to_parse[0]);
+        }
+        return TOML_TYPE_INVALID;
+    }
+    while (qubes_isspace(*end)) {
+        end++;
+    }
+    if (*end == '\0' || *end == '#')
+        return ty;
+    if (ty == TOML_TYPE_INTEGER) {
+        LOG(ERROR, "%s:%zu: Unexpected junk after integer; note that only decimal integers with no excess leading zeros are supported", file, line);
+    } else {
+        LOG(ERROR, "%s:%zu: Unexpected junk after value", file, line);
+    }
+    if (ty == TOML_TYPE_STRING)
+        free(value->string);
+    return TOML_TYPE_INVALID;
+}
+
+static bool qubes_is_key_byte(unsigned char c) {
+    switch (c) {
+    case '0' ... '9':
+    case 'A' ... 'Z':
+    case 'a' ... 'z':
+    case '.':
+    case '-':
+    case '_':
+        return true;
+    default:
+        return false;
+    }
+}
+
+int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user)
+{
+    int result = -1; /* assume problem */
+    FILE *config_file = fopen(config_full_path, "re");
+    if (!config_file) {
+        PERROR("Failed to load %s", config_full_path);
+        return -1;
+    }
+
+    char *current_line = NULL;
+    size_t lineno = 0;
+    size_t bufsize = 0;
+    ssize_t signed_linelen;
+    bool seen_wait_for_session = false;
+    bool seen_user = false;
+    while ((signed_linelen = getline(&current_line, &bufsize, config_file)) != -1) {
+        lineno++;
+        /* Other negative values are invalid.  If nothing at all is read that means EOF. */
+        if (signed_linelen < 1) {
+            LOG(ERROR, "%s:%zu:getline returned invalid value %zd (libc bug?)",
+                config_full_path, lineno, signed_linelen);
+            abort();
+        }
+        size_t linelen = (size_t)signed_linelen;
+        /* Check for NUL in line */
+        if (strlen(current_line) != linelen) {
+            LOG(ERROR, "%s:%zu:NUL byte in line", config_full_path, lineno);
+            goto bad;
+        }
+
+        /* Chop off trailing \n (and \r if present) */
+        if (linelen > 0 && current_line[linelen - 1] == '\n') {
+            linelen--;
+            current_line[linelen] = '\0';
+            if (linelen > 0 && current_line[linelen - 1] == '\r') {
+                linelen--;
+                current_line[linelen] = '\0';
+            }
+        } else {
+            LOG(INFO, "%s:%zu:missing newline at EOF", config_full_path, lineno);
+        }
+        // Multi-line strings not yet implented, so just chop off trailing whitespace
+        while (linelen > 1 && qubes_isspace(current_line[linelen - 1])) {
+            linelen--;
+            current_line[linelen] = '\0';
+        }
+        switch (current_line[0]) {
+        case '\0':
+        case '#':
+            // Skip comments and blank lines
+            continue;
+        case 'a' ... 'z':
+        case 'A' ... 'Z':
+            break;
+        case '[':
+            LOG(ERROR, "%s:%zu: TOML section headers not supported", config_full_path, lineno);
+            goto bad;
+        case ' ':
+        case '\t':
+            LOG(ERROR, "%s:%zu: Unexpected whitespace at start of line", config_full_path, lineno);
+            goto bad;
+        default:
+            if (current_line[0] > ' ' && current_line[0] <= '~') {
+                LOG(ERROR, "%s:%zu: Invalid character '%c' at start of key", config_full_path, lineno, current_line[0]);
+            } else {
+                LOG(ERROR, "%s:%zu: Invalid byte 0x%x at start of key", config_full_path, lineno, current_line[0]);
+            }
+            goto bad;
+        }
+        unsigned char *key_cursor = (unsigned char *)current_line;
+        do {
+            key_cursor++;
+        } while (qubes_is_key_byte(key_cursor[0]));
+        int const key_len = key_cursor - (unsigned char *)current_line;
+        while (qubes_isspace(key_cursor[0]))
+            key_cursor++;
+        if (key_cursor[0] != '=') {
+            LOG(ERROR, "%s:%zu: Missing '=' after key", config_full_path, lineno);
+            goto bad;
+        }
+        do {
+            key_cursor++;
+        } while (qubes_isspace(key_cursor[0]));
+        current_line[key_len] = '\0';
+        union toml_data value;
+        enum toml_type ty = parse_toml_value(config_full_path, lineno, key_cursor, &value);
+
+        if (strcmp(current_line, "wait-for-session") == 0) {
+            if (seen_wait_for_session) {
+                LOG(ERROR, "%s:%zu: Key '%s' appears more than once", config_full_path, lineno, current_line);
+                goto bad;
+            }
+            seen_wait_for_session = true;
+            if (ty == TOML_TYPE_BOOL) {
+                *wait_for_session = (int)value.boolean;
+                continue;
+            } else if (ty == TOML_TYPE_INTEGER) {
+                if (value.integer < 2) {
+                    *wait_for_session = (int)value.integer;
+                    continue;
+                }
+                LOG(ERROR, "Integer value %llu used when a boolean was expected", value.integer);
+            } else if (ty == TOML_TYPE_STRING) {
+                LOG(ERROR, "String value '%s' not valid for 'wait-for-session'", value.string);
+                free(value.string);
+                value.string = NULL;
+            }
+        } else if (strcmp(current_line, "force-user") == 0) {
+            if (seen_user) {
+                LOG(ERROR, "%s:%zu: Key '%s' appears more than once", config_full_path, lineno, current_line);
+                goto bad;
+            }
+            seen_user = true;
+            char *bad_type;
+            switch (ty) {
+            case TOML_TYPE_INVALID:
+                goto bad;
+            case TOML_TYPE_BOOL:
+                bad_type = "Boolean";
+                break;
+            case TOML_TYPE_INTEGER:
+                bad_type = "Integer";
+                break;
+            case TOML_TYPE_STRING:
+                *user = value.string;
+                continue;
+            default:
+                abort();
+            }
+            LOG(ERROR, "%s:%zu: %s not valid for user name or user ID", config_full_path, lineno, bad_type);
+        } else {
+            LOG(ERROR, "%s:%zu: Unsupported key %s", config_full_path, lineno, current_line);
+            continue;
+        }
+        goto bad;
+    }
+
+    result = 1;
+bad:
+    free(current_line);
+    fclose(config_file);
+    return result;
+}

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -363,7 +363,11 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
         with open(
             os.path.join(self.tempdir, "rpc-config", "qubes.Service+arg"), "w"
         ) as f:
-            f.write("wait-for-session=1")
+            f.write("""\
+
+# Test TOML file
+wait-for-session = 1 # line comment
+""")
         user = getpass.getuser()
 
         target = self.execute_qubesrpc("qubes.Service+arg", "domX")


### PR DESCRIPTION
This also dramatically improves the configuration parser.  Configuration files now use a strict subset of TOML rather than an ad-hoc format with no validation.

Fixes: QubesOS/qubes-issues#6354
Fixes: QubesOS/qubes-issues#8153