### PR TITLE
Do not use 'annotation' future extension

### DIFF
--- a/qrexec/exc.py
+++ b/qrexec/exc.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
-from __future__ import annotations
 import pathlib
 from typing import Optional
 

--- a/qrexec/tools/qrexec_policy_exec.py
+++ b/qrexec/tools/qrexec_policy_exec.py
@@ -18,7 +18,6 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
 
-from __future__ import annotations
 import argparse
 import logging
 import logging.handlers

--- a/qrexec/utils.py
+++ b/qrexec/utils.py
@@ -18,7 +18,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
 import json
 import socket
 import subprocess


### PR DESCRIPTION
It isn't available in Python 3.6 (CentOS Stream 8), use manual string
annotations where necessary instead.