### PR TITLE
Fix header validation by qrexec agent

### DIFF
--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -819,7 +819,7 @@ static void handle_trigger_io(void)
     if (!read_all(client_fd, &hdr, sizeof(hdr)))
         goto error;
     if (hdr.type != MSG_TRIGGER_SERVICE3 ||
-            hdr.len < sizeof(params) ||
+            hdr.len <= sizeof(params) ||
             hdr.len > sizeof(params) + MAX_SERVICE_NAME_LEN) {
         LOG(ERROR, "Invalid request received from qrexec-client-vm, is it outdated?");
         goto error;


### PR DESCRIPTION
This ensures that an invalid message (with hdr.len == sizeof(params)) will not be sent to qrexec-daemon.  Starting with the QSB-089 fixes such a message will cause qrexec-daemon to terminate.