### PR TITLE
Banish old-style function declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 MAKEFLAGS=-r
 CC ?= gcc
+CFLAGS += -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-declarations -Werror=missing-prototypes
 PYTHON ?= python3
-export PYTHON GCC MAKEFLAGS
+export PYTHON CC MAKEFLAGS CFLAGS
 
 SYSLIBDIR ?= /lib
 

--- a/agent/Makefile
+++ b/agent/Makefile
@@ -9,7 +9,8 @@ override os := $(shell lsb_release -is)
 override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-	-D_GNU_SOURCE $(CFLAGS) $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM)
+	-D_GNU_SOURCE $(CFLAGS) $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM) \
+	-Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS=-lqrexec-utils $(shell pkg-config --libs $(VCHAN_PKG)) $(if $(HAVE_PAM_APPL),-lpam,)
 

--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -70,7 +70,7 @@ static void sigusr1_handler(int __attribute__((__unused__))x)
     signal(SIGUSR1, SIG_IGN);
 }
 
-void prepare_child_env() {
+void prepare_child_env(void) {
     char pid_s[10];
 
     signal(SIGCHLD, sigchld_handler);

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -873,7 +873,7 @@ struct option longopts[] = {
     { NULL, 0, 0, 0 },
 };
 
-_Noreturn void usage(const char *argv0)
+static _Noreturn void usage(const char *argv0)
 {
     fprintf(stderr, "usage: %s [options]\n", argv0);
     fprintf(stderr, "Options:\n");

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -865,7 +865,7 @@ static void handle_terminated_fork_client(int id) {
     release_connection(id);
 }
 
-struct option longopts[] = {
+static struct option longopts[] = {
     { "help", no_argument, 0, 'h' },
     { "agent-socket", required_argument, 0, 'a' },
     { "fork-server-socket", optional_argument, 0, 's' },

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,9 +1,10 @@
 CC ?=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
-override QUBES_CFLAGS:=-I../libqrexec -g -O2 -Wall -Wextra -Werror -pie -fPIC \
+override QUBES_CFLAGS:=-I../libqrexec -g -O2 -Wall -Wextra -Werror -fPIC \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-   -D_GNU_SOURCE $(CFLAGS)
+   -D_GNU_SOURCE $(CFLAGS) \
+   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS += $(shell pkg-config --libs $(VCHAN_PKG)) -lqrexec-utils
 

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -81,32 +81,32 @@ struct _policy_pending {
    */
 
 #define MAX_CLIENTS MAX_FDS
-struct _client clients[MAX_CLIENTS];	// data on all qrexec_client connections
+static struct _client clients[MAX_CLIENTS];	// data on all qrexec_client connections
 
-struct _policy_pending policy_pending[MAX_CLIENTS];
-int policy_pending_max = -1;
+static struct _policy_pending policy_pending[MAX_CLIENTS];
+static int policy_pending_max = -1;
 
 /* indexed with vchan port number relative to VCHAN_BASE_DATA_PORT; stores
  * either VCHAN_PORT_* or remote domain id for used port */
-int used_vchan_ports[MAX_CLIENTS];
+static int used_vchan_ports[MAX_CLIENTS];
 
 /* notify client (close its connection) when connection initiated by it was
  * terminated - used by qrexec-policy to cleanup (disposable) VM; indexed with
  * vchan port number relative to VCHAN_BASE_DATA_PORT; stores fd of given
  * client or -1 if none requested */
-int vchan_port_notify_client[MAX_CLIENTS];
+static int vchan_port_notify_client[MAX_CLIENTS];
 
-int max_client_fd = -1;		// current max fd of all clients; so that we need not to scan all the "clients" table
-int qrexec_daemon_unix_socket_fd;	// /var/run/qubes/qrexec.xid descriptor
-const char *default_user = "user";
-const char default_user_keyword[] = "DEFAULT:";
+static int max_client_fd = -1;		// current max fd of all clients; so that we need not to scan all the "clients" table
+static int qrexec_daemon_unix_socket_fd;	// /var/run/qubes/qrexec.xid descriptor
+static const char *default_user = "user";
+static const char default_user_keyword[] = "DEFAULT:";
 #define default_user_keyword_len_without_colon (sizeof(default_user_keyword)-2)
 
-int opt_quiet = 0;
-int opt_direct = 0;
+static int opt_quiet = 0;
+static int opt_direct = 0;
 
-const char *socket_dir = QREXEC_DAEMON_SOCKET_DIR;
-const char *policy_program = QREXEC_POLICY_PROGRAM;
+static const char *socket_dir = QREXEC_DAEMON_SOCKET_DIR;
+static const char *policy_program = QREXEC_POLICY_PROGRAM;
 
 #ifdef __GNUC__
 #  define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
@@ -114,11 +114,19 @@ const char *policy_program = QREXEC_POLICY_PROGRAM;
 #  define UNUSED(x) UNUSED_ ## x
 #endif
 
-volatile int children_count;
-volatile int child_exited;
-volatile int terminate_requested;
+static volatile int children_count;
+static volatile int child_exited;
+static volatile int terminate_requested;
 
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+#include "../fuzz/fuzz.h"
+#else
+static
+#endif
 libvchan_t *vchan;
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+static
+#endif
 int protocol_version;
 
 static void sigusr1_handler(int UNUSED(x))
@@ -139,8 +147,8 @@ static void sigchld_parent_handler(int UNUSED(x))
 }
 
 
-char *remote_domain_name;	// guess what
-int remote_domain_id;
+static char *remote_domain_name;	// guess what
+static int remote_domain_id;
 
 static void unlink_qrexec_socket(void)
 {
@@ -1379,7 +1387,7 @@ static int handle_agent_restart(int xid) {
     return 0;
 }
 
-struct option longopts[] = {
+static struct option longopts[] = {
     { "help", no_argument, 0, 'h' },
     { "quiet", no_argument, 0, 'q' },
     { "socket-dir", required_argument, 0, 'd' + 128 },

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -121,14 +121,14 @@ volatile int terminate_requested;
 libvchan_t *vchan;
 int protocol_version;
 
-void sigusr1_handler(int UNUSED(x))
+static void sigusr1_handler(int UNUSED(x))
 {
     if (!opt_quiet)
         LOG(INFO, "Connected to VM");
     exit(0);
 }
 
-void sigchld_parent_handler(int UNUSED(x))
+static void sigchld_parent_handler(int UNUSED(x))
 {
     children_count--;
     /* starting value is 0 so we see dead real qrexec-daemon as -1 */
@@ -142,7 +142,7 @@ void sigchld_parent_handler(int UNUSED(x))
 char *remote_domain_name;	// guess what
 int remote_domain_id;
 
-void unlink_qrexec_socket(void)
+static void unlink_qrexec_socket(void)
 {
     char socket_address[40];
     char link_to_socket_name[strlen(remote_domain_name) + sizeof(socket_address)];
@@ -159,14 +159,14 @@ void unlink_qrexec_socket(void)
     unlink(link_to_socket_name);
 }
 
-void handle_vchan_error(const char *op)
+static void handle_vchan_error(const char *op)
 {
     LOG(ERROR, "Error while vchan %s, exiting", op);
     exit(1);
 }
 
 
-int create_qrexec_socket(int domid, const char *domname)
+static int create_qrexec_socket(int domid, const char *domname)
 {
     char socket_address[40];
     char link_to_socket_name[strlen(domname) + sizeof(socket_address)];
@@ -212,7 +212,7 @@ static void incompatible_protocol_error_message(
     ret = system(text);
 }
 
-int handle_agent_hello(libvchan_t *ctrl, const char *domain_name)
+static int handle_agent_hello(libvchan_t *ctrl, const char *domain_name)
 {
     struct msg_header hdr;
     struct peer_info info;
@@ -264,7 +264,7 @@ int handle_agent_hello(libvchan_t *ctrl, const char *domain_name)
 static void signal_handler(int sig);
 
 /* do the preparatory tasks, needed before entering the main event loop */
-void init(int xid)
+static void init(int xid)
 {
     char qrexec_error_log_name[256];
     int logfd;
@@ -1388,7 +1388,7 @@ struct option longopts[] = {
     { NULL, 0, 0, 0 },
 };
 
-_Noreturn void usage(const char *argv0)
+static _Noreturn void usage(const char *argv0)
 {
     fprintf(stderr, "usage: %s [options] domainid domain-name [default user]\n", argv0);
     fprintf(stderr, "Options:\n");

--- a/fuzz/fuzz.c
+++ b/fuzz/fuzz.c
@@ -122,7 +122,7 @@ ssize_t fuzz_read(int fd, void *buf, size_t count) {
     return count;
 }
 
-volatile char output[256];
+static volatile char output[256];
 
 ssize_t fuzz_write(int fd, const void *buf, size_t count) {
     if (!files[fd].allocated || !files[fd].open_write)

--- a/fuzz/fuzz.h
+++ b/fuzz/fuzz.h
@@ -37,4 +37,8 @@ ssize_t fuzz_write(int fd, const void *buf, size_t count);
 
 void _Noreturn fuzz_exit(int status);
 
+extern fuzz_file_t *vchan;
+extern int protocol_version;
+void handle_message_from_agent(void);
+
 #endif

--- a/fuzz/qrexec_daemon_fuzzer.c
+++ b/fuzz/qrexec_daemon_fuzzer.c
@@ -7,11 +7,7 @@
 #include "libqrexec-utils.h"
 #include "fuzz.h"
 
-extern fuzz_file_t *vchan;
-extern int protocol_version;
-extern void handle_message_from_agent(void);
-
-jmp_buf exit_jmp;
+static jmp_buf exit_jmp;
 
 void _Noreturn fuzz_exit(int status) {
     longjmp(exit_jmp, status);

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -3,7 +3,9 @@ VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-   -D_GNU_SOURCE $(CFLAGS)
+   -D_GNU_SOURCE $(CFLAGS) \
+   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
+
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
 
 override SO_VER=3

--- a/libqrexec/log.c
+++ b/libqrexec/log.c
@@ -31,7 +31,7 @@
 
 static const char *qrexec_program_name = "qrexec";
 
-static void log_time() {
+static void log_time(void) {
     const size_t buf_len = 32;
     char buf[buf_len];
     struct tm tm_buf;

--- a/libqrexec/replace.c
+++ b/libqrexec/replace.c
@@ -19,6 +19,8 @@
  *
  */
 
+#include "libqrexec-utils.h"
+
 void do_replace_chars(char *buf, int len) {
     int i;
     unsigned char c;


### PR DESCRIPTION
They are deprecated in all versions of C and are fundamentally unsafe. Also ensure that all objects with external linkage are declared before being defined.