### PR TITLE
Support Debian 11

### DIFF
--- a/qrexec/utils.py
+++ b/qrexec/utils.py
@@ -25,6 +25,7 @@ from typing import Set, Optional, TypedDict, List, Dict, cast, TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import TypeAlias
 
+# pylint: disable=wrong-import-position
 from . import QUBESD_SOCK, QUBESD_INTERNAL_SOCK
 from .exc import QubesMgmtException
 

--- a/qrexec/utils.py
+++ b/qrexec/utils.py
@@ -21,7 +21,9 @@
 import json
 import socket
 import subprocess
-from typing import Set, Optional, TypedDict, List, Dict, cast, TypeAlias
+from typing import Set, Optional, TypedDict, List, Dict, cast, TYPE_CHECKING
+if TYPE_CHECKING:
+    from typing import TypeAlias
 
 from . import QUBESD_SOCK, QUBESD_INTERNAL_SOCK
 from .exc import QubesMgmtException
@@ -113,7 +115,7 @@ class SystemInfoEntry(TypedDict):
     icon: str
     guivm: Optional[str]
 
-SystemInfo: TypeAlias = Dict[str, SystemInfoEntry]
+SystemInfo: 'TypeAlias' = Dict[str, SystemInfoEntry]
 
 class FullSystemInfo(TypedDict):
     domains: SystemInfo


### PR DESCRIPTION
Debian uses Python 3.9.2 which does not support typing.TypeAlias. Ensure that typing.TypeAlias is only used when type checking.