### PR TITLE
Use a pipe instead of a socket for stderr

### DIFF
--- a/lib/qubes-rpc-multiplexer
+++ b/lib/qubes-rpc-multiplexer
@@ -8,20 +8,17 @@ fi
 # closing file descriptors here - if either stdout or stderr will not be closed
 # when service process does the same - service call will hang (waiting for EOF
 # on stdout/stderr)
-stderr_pipe=/tmp/qrexec-rpc-stderr.$$
-mkfifo $stderr_pipe
-# tee can't write to file descriptor, nor /proc/self/fd/2 (EXIO on open)
-return_stderr_pipe=/tmp/qrexec-rpc-stderr-return.$$
-mkfifo $return_stderr_pipe
-{ cat <$return_stderr_pipe >&2 2>/dev/null; rm -f $return_stderr_pipe; } </dev/null >/dev/null &
-{ tee $return_stderr_pipe <$stderr_pipe |\
-       logger -t "$1-$2"; rm -f $stderr_pipe; } </dev/null >/dev/null 2>&1 &
-exec 2>$stderr_pipe
+stderr_pipe=${XDG_RUNTIME_DIR-/tmp}/qrexec-rpc-stderr.$$
+mkfifo "$stderr_pipe"
+{ tee /proc/self/fd/2 <"$stderr_pipe" |
+       logger -t "$1-$2"; rm -f "$stderr_pipe"; } </dev/null >/dev/null 2>&1 &
+exec 2>"$stderr_pipe"
 
-if ! [ $# = 2 -o $# = 4 ] ; then
+if [ "$#" -ne 2 ] && [ "$#" -ne 4 ]; then
 	echo "$0: bad argument count, usage: $0 SERVICE-NAME REMOTE-DOMAIN-NAME [REQUESTED_TARGET_TYPE REQUESTED_TARGET]" >&2
 	exit 1
 fi
+unset QREXEC_REQUESTED_TARGET QREXEC_REQUESTED_TARGET_KEYWORD
 export QREXEC_REQUESTED_TARGET_TYPE="$3"
 if [ "$QREXEC_REQUESTED_TARGET_TYPE" = "name" ]; then
     export QREXEC_REQUESTED_TARGET="$4"

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -108,7 +108,7 @@ static int do_fork_exec(const char *user,
 #endif
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, inpipe) ||
             socketpair(AF_UNIX, SOCK_STREAM, 0, outpipe) ||
-            (stderr_fd && socketpair(AF_UNIX, SOCK_STREAM, 0, errpipe)) ||
+            (stderr_fd && pipe2(errpipe, O_CLOEXEC)) ||
             socketpair(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0, statuspipe)) {
         PERROR("socketpair");
         exit(1);


### PR DESCRIPTION
qubes-rpc-multiplexer gives the child a FIFO as stderr, so this should not be a compatibility problem.  Also use XDG_RUNTIME_DIR (if present) in preference to /tmp.