### PR TITLE
Make policy.RegisterArgument use new policy format

### DIFF
--- a/qubes-rpc-dom0/policy.RegisterArgument
+++ b/qubes-rpc-dom0/policy.RegisterArgument
@@ -18,7 +18,7 @@
 # License along with this library; if not, see <https://www.gnu.org/licenses/>.
 #
 
-'''policy.RegisterArgument
+"""policy.RegisterArgument
 
 This qrexec is meant for services, which require some kind of "registering"
 before use (say ``example.Register`` and ``example.Perform+ARGUMENT``). After
@@ -38,26 +38,30 @@ drop a policy for an exact call you want to register which will redirect the
 call to dom0.
 
 .. code-block:: none
-    :caption: /etc/qubes-rpc/policy/policy.RegisterArgument+example.Perform
+    :caption: /etc/qubes/policy.d/30-user.policy
 
-    backendvm $anyvm allow,target=dom0
+    policy.RegisterArgument +example.Perform backendvm @anyvm allow,target=dom0
 
 It will generate, for argument ``EXAMPLE``:
 
 .. code-bloc:: none
-    :caption: /etc/qubes-rpc/policy/example.Perform+EXAMPLE
+    :caption: /etc/qubes/policy.d/60-registered-arguments.policy
 
-    frontendvm backendvm allow
-'''
-
+    example.Perform +EXAMPLE frontendvm backendvm allow
+"""
+import contextlib
+import fcntl
 import logging
 import os
 import string
 import sys
 import pathlib
 
-POLICY_PATH = pathlib.Path('/etc/qubes-rpc/policy')
-POLICY_RULE = '{frontend} {backend} allow\n'
+from qrexec.policy.parser import FilePolicy
+from qrexec import POLICYPATH
+
+POLICY_FILE = POLICYPATH / '60-registered-arguments.policy'
+POLICY_RULE = '{service} +{argument} {frontend} {backend} allow\n'
 
 # linux-utils/qrexec-lib/qrexec.h
 MAX_ARGUMENT_LEN = 64
@@ -68,6 +72,20 @@ VALID_CHARS = set(map(ord, string.ascii_letters + string.digits + '-._'))
 def die(*args, **kwargs):
     logging.error(*args, **kwargs)
     sys.exit(1)
+
+@contextlib.contextmanager
+def _lock():
+    """
+    Acquire an exclusive lock to policy directory.
+    """
+
+    lock_fd = os.open(str(POLICYPATH), os.O_DIRECTORY)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(lock_fd)
+
 
 def main():
     # pylint: disable=missing-docstring
@@ -106,22 +124,29 @@ def main():
     del untrusted_argument
     argument = argument.decode('ascii', errors='strict')
 
-    filename = '{}+{}'.format(rpcname, argument)
-    logging.debug('%s %s → %s argument %s filename %s',
-            rpcname, frontend, backend, argument, filename)
+    logging.debug('%s %s → %s argument %s',
+            rpcname, frontend, backend, argument)
 
-    try:
-        # the 'x' enforces that argument cannot be registered twice
-        with open(str(POLICY_PATH / filename), 'x') as file:
-            rule = POLICY_RULE.format(frontend=frontend, backend=backend)
+    with _lock():
+        # check if the argument isn't registered already
+        policy = FilePolicy()
+        for rule in policy.rules:
+            print(repr(rule))
+            if rule.service == rpcname and rule.argument == "+" + argument:
+                die('%s: %s → %s %s argument failed: argument already registered',
+                    rpcname, frontend, backend, argument)
+        with open(str(POLICY_FILE), 'a') as file:
+            rule = POLICY_RULE.format(
+                service=rpcname,
+                argument=argument,
+                frontend=frontend,
+                backend=backend)
             logging.warning('%s: %s → %s %s argument allowed',
                 rpcname, frontend, backend, argument)
             logging.debug('%s: %s → %s %s adding rule %r',
                 rpcname, frontend, backend, rule)
             file.write(rule)
 
-    except FileExistsError:
-        die('%s: %s → %s %s argument failed: file exists')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Make it add rules into
/etc/qubes/policy.d/60-registered-arguments.policy, instead of legacy
/etc/qubes-rpc/policy.
Since the new format can have multiple rules in a single file, locking
is necessary. Do it the same way as other policy.* services, so it's
coordinated too.

QubesOS/qubes-issues#8000