### PR TITLE
Ensure that building qrexec-agent builds libqrexec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ install-dom0: all-dom0
 .PHONY: install-dom0
 
 
-all-vm:
+all-vm: all-base
 	+$(MAKE) all -C agent
 all-vm-selinux:
 	+$(MAKE) -f /usr/share/selinux/devel/Makefile -C selinux qubes-core-qrexec.pp


### PR DESCRIPTION
Otherwise the build fails with an extremely obscure linker error that gives absolutely no clue what the actual problem is.  This change also enables building packages manually via rpmbuild, which is much faster than using qubes-builder.