### PR TITLE
Support additional policy directories

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -368,4 +368,4 @@ exclude-protected=_asdict,_fields,_replace,_source,_make
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception,builtins.BaseException

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,8 @@ install-dom0: all-dom0
 	install -t $(DESTDIR)/etc/qubes/policy.d/include -m 664 policy.d/include/*
 	install -d $(DESTDIR)/lib/systemd/system -m 755
 	install -t $(DESTDIR)/lib/systemd/system -m 644 systemd/qubes-qrexec-policy-daemon.service
+	install -m 755 -d $(DESTDIR)/usr/lib/tmpfiles.d/
+	install -m 0644 -t $(DESTDIR)/usr/lib/tmpfiles.d/ systemd/qrexec.conf
 .PHONY: install-dom0
 
 

--- a/qrexec/__init__.py
+++ b/qrexec/__init__.py
@@ -38,10 +38,12 @@ QUBESD_SOCK = "/var/run/qubesd.sock"
 RPC_PATH = "/etc/qubes-rpc"
 POLICY_AGENT_SOCKET_PATH = "/var/run/qubes/policy-agent.sock"
 POLICYPATH = pathlib.Path("/etc/qubes/policy.d")
+RUNTIME_POLICY_PATH = pathlib.Path("/run/qubes/policy.d")
 POLICYSOCKET = pathlib.Path("/var/run/qubes/policy.sock")
 POLICY_EVAL_SOCKET = pathlib.Path("/etc/qubes-rpc/policy.EvalSimple")
 POLICY_GUI_SOCKET = pathlib.Path("/etc/qubes-rpc/policy.EvalGUI")
 INCLUDEPATH = POLICYPATH / "include"
+RUNTIME_INCLUDE_PATH = RUNTIME_POLICY_PATH / "include"
 POLICYSUFFIX = ".policy"
 POLICYPATH_OLD = pathlib.Path("/etc/qubes-rpc/policy")
 

--- a/qrexec/tests/cli.py
+++ b/qrexec/tests/cli.py
@@ -96,7 +96,7 @@ def policy():
         yield policy
 
     assert mock_policy.mock_calls == [
-        mock.call(policy_path=PosixPath("/etc/qubes/policy.d"))
+        mock.call(policy_path=[PosixPath("/run/qubes/policy.d"), PosixPath("/etc/qubes/policy.d")]),
     ]
 
 

--- a/qrexec/tests/policy_cache.py
+++ b/qrexec/tests/policy_cache.py
@@ -23,11 +23,20 @@ import asyncio
 import pytest
 import unittest
 import unittest.mock
+import pathlib
 
 from ..policy import utils
 
 
 class TestPolicyCache:
+    @pytest.fixture
+    def tmp_paths(self, tmp_path: pathlib.Path) -> list[pathlib.Path]:
+        path1 = tmp_path / "path1"
+        path2 = tmp_path / "path2"
+        path1.mkdir()
+        path2.mkdir()
+        return [path1, path2]
+
     @pytest.fixture
     def mock_parser(self, monkeypatch):
         mock_parser = unittest.mock.Mock()
@@ -37,58 +46,60 @@ class TestPolicyCache:
         return mock_parser
 
     def test_00_policy_init(self, tmp_path, mock_parser):
-        cache = utils.PolicyCache(tmp_path)
-        mock_parser.assert_called_once_with(policy_path=tmp_path)
+        cache = utils.PolicyCache([tmp_path])
+        mock_parser.assert_called_once_with(policy_path=[tmp_path])
 
     @pytest.mark.asyncio
-    async def test_10_file_created(self, tmp_path, mock_parser):
-        cache = utils.PolicyCache(tmp_path)
-        cache.initialize_watcher()
+    async def test_10_file_created(self, tmp_paths, mock_parser):
+        for i in tmp_paths:
+            cache = utils.PolicyCache(tmp_paths)
+            cache.initialize_watcher()
 
-        assert not cache.outdated
+            assert not cache.outdated
 
-        file = tmp_path / "test"
-        file.write_text("test")
+            (i / "file").write_text("test")
 
-        await asyncio.sleep(1)
+            await asyncio.sleep(1)
 
-        assert cache.outdated
-
-    @pytest.mark.asyncio
-    async def test_11_file_changed(self, tmp_path, mock_parser):
-        file = tmp_path / "test"
-        file.write_text("test")
-
-        cache = utils.PolicyCache(tmp_path)
-        cache.initialize_watcher()
-
-        assert not cache.outdated
-
-        file.write_text("new_content")
-
-        await asyncio.sleep(1)
-
-        assert cache.outdated
+            assert cache.outdated
 
     @pytest.mark.asyncio
-    async def test_12_file_deleted(self, tmp_path, mock_parser):
-        file = tmp_path / "test"
-        file.write_text("test")
+    async def test_11_file_changed(self, tmp_paths, mock_parser):
+        for i in tmp_paths:
+            file = i / "test"
+            file.write_text("test")
 
-        cache = utils.PolicyCache(tmp_path)
-        cache.initialize_watcher()
+            cache = utils.PolicyCache(tmp_paths)
+            cache.initialize_watcher()
 
-        assert not cache.outdated
+            assert not cache.outdated
 
-        os.remove(file)
+            file.write_text("new_content")
 
-        await asyncio.sleep(1)
+            await asyncio.sleep(1)
 
-        assert cache.outdated
+            assert cache.outdated
 
     @pytest.mark.asyncio
-    async def test_13_no_change(self, tmp_path, mock_parser):
-        cache = utils.PolicyCache(tmp_path)
+    async def test_12_file_deleted(self, tmp_paths, mock_parser):
+        for i in tmp_paths:
+            file = i / "test"
+            file.write_text("test")
+
+            cache = utils.PolicyCache(tmp_paths)
+            cache.initialize_watcher()
+
+            assert not cache.outdated
+
+            os.remove(file)
+
+            await asyncio.sleep(1)
+
+            assert cache.outdated
+
+    @pytest.mark.asyncio
+    async def test_13_no_change(self, tmp_paths, mock_parser):
+        cache = utils.PolicyCache(tmp_paths)
         cache.initialize_watcher()
 
         assert not cache.outdated
@@ -101,10 +112,10 @@ class TestPolicyCache:
     async def test_14_policy_move(self, tmp_path, mock_parser):
         policy_path = tmp_path / "policy"
         policy_path.mkdir()
-        cache = utils.PolicyCache(policy_path)
+        cache = utils.PolicyCache([policy_path])
         cache.initialize_watcher()
 
-        mock_parser.assert_called_once_with(policy_path=policy_path)
+        mock_parser.assert_called_once_with(policy_path=[policy_path])
 
         assert not cache.outdated
 
@@ -135,27 +146,35 @@ class TestPolicyCache:
 
         cache.get_policy()
 
-        call = unittest.mock.call(policy_path=policy_path)
+        call = unittest.mock.call(policy_path=[policy_path])
         assert mock_parser.mock_calls == [call, call, call]
 
     @pytest.mark.asyncio
-    async def test_20_policy_updates(self, tmp_path, mock_parser):
-        cache = utils.PolicyCache(tmp_path)
+    async def test_20_policy_updates(self, tmp_paths, mock_parser):
+        cache = utils.PolicyCache(tmp_paths)
         cache.initialize_watcher()
+        count = 0
 
-        mock_parser.assert_called_once_with(policy_path=tmp_path)
+        for i in tmp_paths:
+            call = unittest.mock.call(policy_path=tmp_paths)
 
-        assert not cache.outdated
+            count += 2
+            assert mock_parser.mock_calls == [call] * (count - 1)
+            cache = utils.PolicyCache(tmp_paths)
+            cache.initialize_watcher()
 
-        file = tmp_path / "test"
-        file.write_text("test")
+            l = len(mock_parser.mock_calls)
+            assert mock_parser.mock_calls == [call] * l
 
-        await asyncio.sleep(1)
+            assert not cache.outdated
 
-        assert cache.outdated
+            file = i / "test"
+            file.write_text("test")
 
-        cache.get_policy()
+            await asyncio.sleep(1)
 
-        call = unittest.mock.call(policy_path=tmp_path)
+            assert cache.outdated
 
-        assert mock_parser.mock_calls == [call, call]
+            cache.get_policy()
+
+            assert mock_parser.mock_calls == [call] * (count + 1)

--- a/qrexec/tools/qrexec_legacy_convert.py
+++ b/qrexec/tools/qrexec_legacy_convert.py
@@ -288,7 +288,7 @@ def main(args=None):
                                   str(POLICYPATH), '--full-output'],
                                  output=current_state_string)
         current_state = set(current_state_string.getvalue().split('\n'))
-    except Exception: #pylint: disable-broad-except
+    except Exception: # pylint: disable=broad-except
         current_state = 'ERROR'
 
     if initial_state != current_state:

--- a/qrexec/tools/qrexec_policy_daemon.py
+++ b/qrexec/tools/qrexec_policy_daemon.py
@@ -27,7 +27,7 @@ import os
 
 from ..utils import sanitize_domain_name, get_system_info
 from .qrexec_policy_exec import handle_request
-from .. import POLICYPATH, POLICYSOCKET, POLICY_EVAL_SOCKET, POLICY_GUI_SOCKET
+from .. import POLICYPATH, POLICYSOCKET, POLICY_EVAL_SOCKET, POLICY_GUI_SOCKET, RUNTIME_POLICY_PATH
 from ..policy.utils import PolicyCache
 
 argparser = argparse.ArgumentParser(description="Evaluate qrexec policy daemon")
@@ -35,8 +35,9 @@ argparser = argparse.ArgumentParser(description="Evaluate qrexec policy daemon")
 argparser.add_argument(
     "--policy-path",
     type=pathlib.Path,
-    default=POLICYPATH,
+    default=[RUNTIME_POLICY_PATH, POLICYPATH],
     help="Use alternative policy path",
+    action='append',
 )
 argparser.add_argument(
     "--socket-path",
@@ -291,6 +292,8 @@ async def handle_qrexec_connection(
 
 async def start_serving(args=None):
     args = argparser.parse_args(args)
+    if len(args.policy_path) > 2:
+        args.policy_path = args.policy_path[2:]
 
     logging.basicConfig(format="%(message)s")
     log = logging.getLogger("policy")

--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -122,6 +122,7 @@ rm -f %{name}-%{version}
 %{_sysconfdir}/qubes-rpc/policy.include.Get
 %{_sysconfdir}/qubes-rpc/policy.include.Replace
 %{_sysconfdir}/qubes-rpc/policy.include.Remove
+%{_tmpfilesdir}/qrexec.conf
 
 /lib/systemd/system/qubes-qrexec-policy-daemon.service
 

--- a/systemd/qrexec.conf
+++ b/systemd/qrexec.conf
@@ -1,0 +1,2 @@
+d /run/qubes          2770 root qubes
+d /run/qubes/policy.d 2770 root qubes


### PR DESCRIPTION
This allows multiple directories to contain qrexec policy, which allows for transient policy that disappears on reboot.

Fixes: QubesOS/qubes-issues#8513