### PR TITLE
Avoid using qrexec-client for VM ⇒ VM calls

### DIFF
--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -846,7 +846,9 @@ static void handle_trigger_io(void)
     if (command[command_len-1] != '\0')
         goto error;
 
-    snprintf(params.request_id.ident, sizeof(params.request_id), "SOCKET%d", client_fd);
+    int res = snprintf(params.request_id.ident, sizeof(params.request_id), "SOCKET%d", client_fd);
+    if (res < 0 || res >= (int)sizeof(params.request_id))
+        abort();
     if (libvchan_send(ctrl_vchan, &hdr, sizeof(hdr)) != sizeof(hdr))
         handle_vchan_error("write hdr");
     if (libvchan_send(ctrl_vchan, &params, sizeof(params)) != sizeof(params))

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -232,8 +232,7 @@ int main(int argc, char **argv)
     strncpy(params.target_domain, argv[optind],
             sizeof(params.target_domain) - 1);
 
-    snprintf(params.request_id.ident,
-            sizeof(params.request_id.ident), "SOCKET");
+    memcpy(params.request_id.ident, "SOCKET", sizeof("SOCKET"));
 
     if (!write_all(trigger_fd, &hdr, sizeof(hdr))) {
         PERROR("write(hdr) to agent");

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -4,7 +4,8 @@ override QUBES_CFLAGS:=-I../libqrexec -g -O2 -Wall -Wextra -Werror -fPIC \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
    -D_GNU_SOURCE $(CFLAGS) \
-   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
+   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations \
+   -fvisibility=hidden
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
 override LDLIBS += $(shell pkg-config --libs $(VCHAN_PKG)) -lqrexec-utils
 
@@ -22,8 +23,8 @@ install: all
 	ln -sf ../../bin/qrexec-client $(DESTDIR)/usr/lib/qubes/qrexec-client
 .PHONY: all clean install
 
-qrexec-daemon qrexec-client: %: %.o
-	$(CC) $(LDFLAGS) -pie -g -o $@ $< $(LDLIBS)
+qrexec-daemon qrexec-client: %: %.o qrexec-daemon-common.o
+	$(CC) $(LDFLAGS) -pie -g -o $@ $^ $(LDLIBS)
 
 %.o: %.c
 	$(CC) $< -c -o $@ $(QUBES_CFLAGS) -MD -MP -MF $@.dep

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -187,7 +187,7 @@ static int connect_unix_socket(const char *domname)
     if (res >= (int)sizeof(remote.sun_path))
         errx(1, "%s/qrexec.%s is too long for AF_UNIX socket path",
              socket_dir, domname);
-    len = strlen(remote.sun_path) + sizeof(remote.sun_family);
+    len = (size_t)res + 1 + offsetof(struct sockaddr_un, sun_path);
     if (connect(s, (struct sockaddr *) &remote, len) == -1) {
         PERROR("connect");
         exit(1);

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -541,7 +541,6 @@ int main(int argc, char **argv)
     libvchan_t *data_vchan = NULL;
     int data_port;
     int data_domain;
-    int msg_type;
     int s;
     bool just_exec = false;
     int wait_connection_end = 0;
@@ -633,7 +632,6 @@ int main(int argc, char **argv)
             fprintf(stderr, "ERROR: when target domain is 'dom0', -c must be specified\n");
             usage(argv[0]);
         }
-        msg_type = MSG_SERVICE_CONNECT;
         strncpy(svc_params.ident, request_id, sizeof(svc_params.ident) - 1);
         svc_params.ident[sizeof(svc_params.ident) - 1] = '\0';
         if (src_domain_name == NULL) {
@@ -644,7 +642,7 @@ int main(int argc, char **argv)
         s = connect_unix_socket(src_domain_id_str);
         negotiate_connection_params(s,
                 0, /* dom0 */
-                msg_type,
+                MSG_SERVICE_CONNECT,
                 (void*)&svc_params,
                 sizeof(svc_params),
                 &data_domain,
@@ -678,11 +676,10 @@ int main(int argc, char **argv)
             handle_failed_exec(data_vchan);
         select_loop(data_vchan, data_protocol_version, &stdin_buffer);
     } else {
-        msg_type = just_exec ? MSG_JUST_EXEC : MSG_EXEC_CMDLINE;
         s = connect_unix_socket(domname);
         negotiate_connection_params(s,
                 src_domain_id,
-                msg_type,
+                just_exec ? MSG_JUST_EXEC : MSG_EXEC_CMDLINE,
                 remote_cmdline,
                 compute_service_length(remote_cmdline, argv[0]),
                 &data_domain,

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -41,8 +41,8 @@
 #include "libqrexec-utils.h"
 
 // whether qrexec-client should replace problematic bytes with _ before printing the output
-static int replace_chars_stdout = 0;
-static int replace_chars_stderr = 0;
+static bool replace_chars_stdout = false;
+static bool replace_chars_stderr = false;
 
 static int exit_with_code = 1;
 
@@ -54,7 +54,7 @@ static int local_stdin_fd, local_stdout_fd;
 static pid_t local_pid = 0;
 /* flag if this is "remote" end of service call. In this case swap STDIN/STDOUT
  * msg types and send exit code at the end */
-static int is_service = 0;
+static bool is_service = false;
 
 static volatile sig_atomic_t sigchld = 0;
 
@@ -543,7 +543,7 @@ int main(int argc, char **argv)
     int data_domain;
     int msg_type;
     int s;
-    int just_exec = 0;
+    bool just_exec = false;
     int wait_connection_end = 0;
     char *local_cmdline = NULL;
     char *remote_cmdline = NULL;
@@ -572,7 +572,7 @@ int main(int argc, char **argv)
                 local_cmdline = xstrdup(optarg);
                 break;
             case 'e':
-                just_exec = 1;
+                just_exec = true;
                 break;
             case 'E':
                 exit_with_code = 0;
@@ -583,13 +583,13 @@ int main(int argc, char **argv)
                     usage(argv[0]);
                 }
                 parse_connect(optarg, &request_id, &src_domain_name, &src_domain_id);
-                is_service = 1;
+                is_service = true;
                 break;
             case 't':
-                replace_chars_stdout = 1;
+                replace_chars_stdout = true;
                 break;
             case 'T':
-                replace_chars_stderr = 1;
+                replace_chars_stderr = true;
                 break;
             case 'w':
                 connection_timeout = parse_int(optarg, "connection timeout");
@@ -616,7 +616,7 @@ int main(int argc, char **argv)
 
     register_exec_func(&do_exec);
 
-    if (just_exec + (request_id != NULL) + (local_cmdline != 0) > 1) {
+    if (just_exec + (request_id != NULL) + (local_cmdline != NULL) > 1) {
         fprintf(stderr, "ERROR: only one of -e, -l, -c can be specified\n");
         usage(argv[0]);
     }

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -693,10 +693,6 @@ int main(int argc, char **argv)
             wait_connection_end = s;
         else
             close(s);
-        set_remote_domain(domname);
-        struct buffer stdin_buffer;
-        buffer_init(&stdin_buffer);
-        prepare_ret = prepare_local_fds(local_cmdline, &stdin_buffer);
         if (request_id) {
             s = connect_unix_socket(src_domain_id_str);
             send_service_connect(s, request_id, data_domain, data_port);
@@ -709,6 +705,10 @@ int main(int argc, char **argv)
                 poll(fds, 1, -1);
             }
         } else {
+            set_remote_domain(domname);
+            struct buffer stdin_buffer;
+            buffer_init(&stdin_buffer);
+            prepare_ret = prepare_local_fds(local_cmdline, &stdin_buffer);
             data_vchan = libvchan_server_init(data_domain, data_port,
                     VCHAN_BUFFER_SIZE, VCHAN_BUFFER_SIZE);
             if (!data_vchan) {

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -621,6 +621,13 @@ int main(int argc, char **argv)
         usage(argv[0]);
     }
 
+    char src_domain_id_str[11];
+    {
+        int snprintf_res = snprintf(src_domain_id_str, sizeof(src_domain_id_str), "%d", src_domain_id);
+        if (snprintf_res < 0 || snprintf_res >= (int)sizeof(src_domain_id_str))
+            err(1, "snprintf()");
+    }
+
     if (strcmp(domname, "dom0") == 0 || strcmp(domname, "@adminvm") == 0) {
         if (request_id != NULL) {
             msg_type = MSG_SERVICE_CONNECT;
@@ -635,7 +642,7 @@ int main(int argc, char **argv)
             abort();
         }
         set_remote_domain(src_domain_name);
-        s = connect_unix_socket(src_domain_name);
+        s = connect_unix_socket(src_domain_id_str);
         negotiate_connection_params(s,
                 0, /* dom0 */
                 msg_type,
@@ -698,7 +705,7 @@ int main(int argc, char **argv)
         buffer_init(&stdin_buffer);
         prepare_ret = prepare_local_fds(local_cmdline, &stdin_buffer);
         if (request_id) {
-            s = connect_unix_socket(src_domain_name);
+            s = connect_unix_socket(src_domain_id_str);
             send_service_connect(s, request_id, data_domain, data_port);
             close(s);
             if (wait_connection_end) {

--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -1,0 +1,152 @@
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdio.h>
+
+#include "qrexec.h"
+#include "libqrexec-utils.h"
+#include "qrexec-daemon-common.h"
+
+const char *socket_dir = QREXEC_DAEMON_SOCKET_DIR;
+
+/* ask the daemon to allocate vchan port */
+bool negotiate_connection_params(int s, int other_domid, unsigned type,
+        void *cmdline_param, int cmdline_size,
+        int *data_domain, int *data_port)
+{
+    struct msg_header hdr;
+    struct exec_params params;
+    hdr.type = type;
+    hdr.len = sizeof(params) + cmdline_size;
+    params.connect_domain = other_domid;
+    params.connect_port = 0;
+    if (!write_all(s, &hdr, sizeof(hdr))
+            || !write_all(s, &params, sizeof(params))
+            || !write_all(s, cmdline_param, cmdline_size)) {
+        PERROR("write daemon");
+        return false;
+    }
+    /* the daemon will respond with the same message with connect_port filled
+     * and empty cmdline */
+    if (!read_all(s, &hdr, sizeof(hdr))) {
+        PERROR("read daemon");
+        return false;
+    }
+    assert(hdr.type == type);
+    if (hdr.len != sizeof(params)) {
+        LOG(ERROR, "Invalid response for 0x%x", type);
+        return false;
+    }
+    if (!read_all(s, &params, sizeof(params))) {
+        PERROR("read daemon");
+        return false;
+    }
+    *data_port = params.connect_port;
+    *data_domain = params.connect_domain;
+    return true;
+}
+
+int handle_daemon_handshake(int fd)
+{
+    struct msg_header hdr;
+    struct peer_info info;
+
+    /* daemon send MSG_HELLO first */
+    if (!read_all(fd, &hdr, sizeof(hdr))) {
+        PERROR("daemon handshake");
+        return -1;
+    }
+    if (hdr.type != MSG_HELLO || hdr.len != sizeof(info)) {
+        LOG(ERROR, "Invalid daemon MSG_HELLO");
+        return -1;
+    }
+    if (!read_all(fd, &info, sizeof(info))) {
+        PERROR("daemon handshake");
+        return -1;
+    }
+
+    if (info.version != QREXEC_PROTOCOL_VERSION) {
+        LOG(ERROR, "Incompatible daemon protocol version "
+            "(daemon %d, client %d)",
+            info.version, QREXEC_PROTOCOL_VERSION);
+        return -1;
+    }
+
+    hdr.type = MSG_HELLO;
+    hdr.len = sizeof(info);
+    info.version = QREXEC_PROTOCOL_VERSION;
+
+    if (!write_all(fd, &hdr, sizeof(hdr))) {
+        LOG(ERROR, "Failed to send MSG_HELLO hdr to daemon");
+        return -1;
+    }
+    if (!write_all(fd, &info, sizeof(info))) {
+        LOG(ERROR, "Failed to send MSG_HELLO to daemon");
+        return -1;
+    }
+    return 0;
+}
+
+int connect_unix_socket_by_id(unsigned int domid)
+{
+    char id_str[11];
+    int snprintf_res = snprintf(id_str, sizeof(id_str), "%u", domid);
+    if (snprintf_res < 0 || snprintf_res >= (int)sizeof(id_str))
+        abort();
+    return connect_unix_socket(id_str);
+}
+
+int connect_unix_socket(const char *domname)
+{
+    int s, len, res;
+    struct sockaddr_un remote;
+
+    if ((s = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+        LOG(ERROR, "socket() failed: %m");
+        return -1;
+    }
+
+    remote.sun_family = AF_UNIX;
+    res = snprintf(remote.sun_path, sizeof remote.sun_path,
+                   "%s/qrexec.%s", socket_dir, domname);
+    if (res < 0)
+        abort();
+    if (res >= (int)sizeof(remote.sun_path)) {
+        LOG(ERROR, "%s/qrexec.%s is too long for AF_UNIX socket path",
+             socket_dir, domname);
+        return -1;
+    }
+    len = (size_t)res + 1 + offsetof(struct sockaddr_un, sun_path);
+    if (connect(s, (struct sockaddr *) &remote, len) == -1) {
+        LOG(ERROR, "connect %s", remote.sun_path);
+        return -1;
+    }
+    if (handle_daemon_handshake(s) < 0)
+        return -1;
+    return s;
+}
+
+bool send_service_connect(int s, const char *conn_ident,
+        int connect_domain, int connect_port)
+{
+    struct msg_header hdr;
+    struct exec_params exec_params;
+    struct service_params srv_params;
+
+    hdr.type = MSG_SERVICE_CONNECT;
+    hdr.len = sizeof(exec_params) + sizeof(srv_params);
+
+    exec_params.connect_domain = connect_domain;
+    exec_params.connect_port = connect_port;
+    strncpy(srv_params.ident, conn_ident, sizeof(srv_params.ident) - 1);
+    srv_params.ident[sizeof(srv_params.ident) - 1] = '\0';
+
+    if (!write_all(s, &hdr, sizeof(hdr))
+            || !write_all(s, &exec_params, sizeof(exec_params))
+            || !write_all(s, &srv_params, sizeof(srv_params))) {
+        PERROR("write daemon");
+        return false;
+    }
+    return true;
+}

--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <sys/wait.h>
 #include <stdio.h>
 
 #include "qrexec.h"
@@ -12,7 +13,7 @@ const char *socket_dir = QREXEC_DAEMON_SOCKET_DIR;
 
 /* ask the daemon to allocate vchan port */
 bool negotiate_connection_params(int s, int other_domid, unsigned type,
-        void *cmdline_param, int cmdline_size,
+        const void *cmdline_param, int cmdline_size,
         int *data_domain, int *data_port)
 {
     struct msg_header hdr;
@@ -149,4 +150,269 @@ bool send_service_connect(int s, const char *conn_ident,
         return false;
     }
     return true;
+}
+
+#define QREXEC_DATA_MIN_VERSION QREXEC_PROTOCOL_V2
+
+static int local_stdin_fd = 1, local_stdout_fd = 0;
+static pid_t local_pid = 0;
+
+static volatile sig_atomic_t sigchld = 0;
+
+static void set_remote_domain(const char *src_domain_name) {
+    if (setenv("QREXEC_REMOTE_DOMAIN", src_domain_name, 1)) {
+        LOG(ERROR, "Cannot set QREXEC_REMOTE_DOMAIN");
+        abort();
+    }
+}
+
+/* initialize data_protocol_version */
+int handle_agent_handshake(libvchan_t *vchan, bool remote_send_first)
+{
+    struct msg_header hdr;
+    struct peer_info info;
+    int data_protocol_version = -1;
+    int who = 0; // even - send to remote, odd - receive from remote
+
+    while (who < 2) {
+        if ((who+remote_send_first) & 1) {
+            if (!read_vchan_all(vchan, &hdr, sizeof(hdr))) {
+                PERROR("daemon handshake");
+                return -1;
+            }
+            if (hdr.type != MSG_HELLO || hdr.len != sizeof(info)) {
+                LOG(ERROR, "Invalid daemon MSG_HELLO");
+                return -1;
+            }
+            if (!read_vchan_all(vchan, &info, sizeof(info))) {
+                PERROR("daemon handshake");
+                return -1;
+            }
+
+            data_protocol_version = info.version < QREXEC_PROTOCOL_VERSION ?
+                                    info.version : QREXEC_PROTOCOL_VERSION;
+            if (data_protocol_version < QREXEC_DATA_MIN_VERSION) {
+                LOG(ERROR, "Incompatible daemon protocol version "
+                        "(daemon %d, client %d)",
+                        info.version, QREXEC_PROTOCOL_VERSION);
+                return -1;
+            }
+        } else {
+            hdr.type = MSG_HELLO;
+            hdr.len = sizeof(info);
+            info.version = QREXEC_PROTOCOL_VERSION;
+
+            if (!write_vchan_all(vchan, &hdr, sizeof(hdr))) {
+                LOG(ERROR, "Failed to send MSG_HELLO hdr to daemon");
+                return -1;
+            }
+            if (!write_vchan_all(vchan, &info, sizeof(info))) {
+                LOG(ERROR, "Failed to send MSG_HELLO to daemon");
+                return -1;
+            }
+        }
+        who++;
+    }
+    return data_protocol_version;
+}
+
+static void sigchld_handler(int x __attribute__((__unused__)))
+{
+    sigchld = 1;
+    signal(SIGCHLD, sigchld_handler);
+}
+
+/* See also qrexec-agent.c:wait_for_session_maybe() */
+static bool wait_for_session_maybe(struct qrexec_parsed_command *cmd)
+{
+    pid_t pid;
+    int status;
+
+    if (cmd->nogui) {
+        return true;
+    }
+
+    if (!cmd->service_descriptor) {
+        return true;
+    }
+
+    if (load_service_config_v2(cmd) < 0) {
+        return false;
+    }
+
+    if (!cmd->wait_for_session) {
+        return true;
+    }
+
+    pid = fork();
+    switch (pid) {
+        case 0:
+            close(0);
+            exec_wait_for_session(cmd->source_domain);
+            PERROR("exec");
+            _exit(1);
+        case -1:
+            PERROR("fork");
+            return false;
+        default:
+            break;
+    }
+
+    if (waitpid(local_pid, &status, 0) > 0) {
+        if (status != 0)
+            LOG(ERROR, "wait-for-session exited with status %d", status);
+    } else
+        PERROR("waitpid");
+
+    return true;
+}
+
+int prepare_local_fds(struct qrexec_parsed_command *command, struct buffer *stdin_buffer)
+{
+    if (stdin_buffer == NULL)
+        abort();
+    if (signal(SIGCHLD, sigchld_handler) == SIG_ERR)
+        return 126;
+    return execute_parsed_qubes_rpc_command(command, &local_pid, &local_stdin_fd, &local_stdout_fd,
+            NULL, stdin_buffer);
+}
+
+// See also qrexec-agent/qrexec-agent-data.c
+__attribute__((warn_unused_result))
+static int handle_failed_exec(libvchan_t *data_vchan, bool is_service)
+{
+    int exit_code = 127;
+    struct msg_header hdr = {
+        .type = MSG_DATA_STDOUT,
+        .len = 0,
+    };
+
+    LOG(ERROR, "failed to spawn process, exiting");
+    /*
+     * TODO: In case we fail to execute a *local* process (is_service false),
+     * we should either
+     *  - exit even before connecting to remote domain, or
+     *  - send stdin EOF and keep waiting for remote exit code.
+     *
+     * That will require a slightly bigger refactoring. Right now it's not
+     * important, because this function should handle QUBESRPC command failure
+     * only (normal commands go through fork+exec), but it will be necessary
+     * when we support sockets as a local process.
+     */
+    if (is_service) {
+        libvchan_send(data_vchan, &hdr, sizeof(hdr));
+        send_exit_code(data_vchan, exit_code);
+    }
+    return exit_code;
+}
+
+static int select_loop(struct handshake_params *params)
+{
+    struct process_io_request req = { 0 };
+    int exit_code;
+
+    req.vchan = params->data_vchan;
+    req.stdin_buf = params->stdin_buffer;
+    req.stdin_fd = local_stdin_fd;
+    req.stdout_fd = local_stdout_fd;
+    req.stderr_fd = -1;
+    req.local_pid = local_pid;
+    req.is_service = params->remote_send_first;
+    req.replace_chars_stdout = params->replace_chars_stdout;
+    req.replace_chars_stderr = params->replace_chars_stderr;
+    req.data_protocol_version = params->data_protocol_version;
+    req.sigchld = &sigchld;
+    req.sigusr1 = NULL;
+    req.prefix_data.data = NULL;
+    req.prefix_data.len = 0;
+
+    exit_code = process_io(&req);
+    return (params->exit_with_code ? exit_code : 0);
+}
+
+static void sigalrm_handler(int x __attribute__((__unused__)))
+{
+    LOG(ERROR, "vchan connection timeout");
+    _exit(1);
+}
+
+int run_qrexec_to_dom0(const struct service_params *svc_params,
+                        int src_domain_id,
+                        const char *src_domain_name,
+                        char *remote_cmdline,
+                        int connection_timeout,
+                        bool exit_with_code)
+{
+    int data_domain;
+    int data_port;
+    int s;
+    int prepare_ret;
+    libvchan_t *data_vchan = NULL;
+
+    set_remote_domain(src_domain_name);
+    s = connect_unix_socket_by_id(src_domain_id);
+    if (s < 0)
+        return 126;
+    if (!negotiate_connection_params(s,
+            0, /* dom0 */
+            MSG_SERVICE_CONNECT,
+            svc_params,
+            sizeof(*svc_params),
+            &data_domain,
+            &data_port))
+        return 126;
+
+    struct buffer stdin_buffer;
+    buffer_init(&stdin_buffer);
+    struct qrexec_parsed_command *command =
+        parse_qubes_rpc_command(remote_cmdline, false);
+    if (command == NULL) {
+        prepare_ret = -1;
+    } else if (!wait_for_session_maybe(command)) {
+        LOG(ERROR, "Cannot load service configuration, or forking process failed");
+        prepare_ret = -1;
+    } else {
+        prepare_ret = prepare_local_fds(command, &stdin_buffer);
+    }
+    void (*old_handler)(int);
+
+    /* libvchan_client_init is blocking and does not support connection
+     * timeout, so use alarm(2) for that... */
+    old_handler = signal(SIGALRM, sigalrm_handler);
+    alarm(connection_timeout);
+    data_vchan = libvchan_client_init(data_domain, data_port);
+    alarm(0);
+    signal(SIGALRM, old_handler);
+    struct handshake_params params = {
+        .data_vchan = data_vchan,
+        .stdin_buffer = &stdin_buffer,
+        .remote_send_first = true, // this is a service call _to_ dom0
+        .prepare_ret = prepare_ret,
+        .exit_with_code = exit_with_code,
+        .replace_chars_stdout = false, // stdout is _from_ dom0
+        .replace_chars_stderr = false, // stderr is _from_ dom0
+    };
+    return handshake_and_go(&params);
+}
+
+int handshake_and_go(struct handshake_params *params)
+{
+    if (params->data_vchan == NULL || !libvchan_is_open(params->data_vchan)) {
+        LOG(ERROR, "Failed to open data vchan connection");
+        return 126;
+    }
+    int rc;
+    int data_protocol_version = handle_agent_handshake(params->data_vchan,
+                                                       params->remote_send_first);
+    if (data_protocol_version < 0) {
+        rc = 126;
+    } else if (params->prepare_ret < 0) {
+        rc = handle_failed_exec(params->data_vchan, params->remote_send_first);
+    } else {
+        params->data_protocol_version = data_protocol_version;
+        rc = select_loop(params);
+    }
+    libvchan_close(params->data_vchan);
+    params->data_vchan = NULL;
+    return rc;
 }

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -1,0 +1,14 @@
+extern const char *socket_dir;
+__attribute__((warn_unused_result))
+int connect_unix_socket_by_id(unsigned int domid);
+__attribute__((warn_unused_result))
+int connect_unix_socket(const char *domname);
+__attribute__((warn_unused_result))
+int handle_daemon_handshake(int fd);
+__attribute__((warn_unused_result))
+bool negotiate_connection_params(int s, int other_domid, unsigned type,
+        void *cmdline_param, int cmdline_size,
+        int *data_domain, int *data_port);
+__attribute__((warn_unused_result))
+bool send_service_connect(int s, const char *conn_ident,
+        int connect_domain, int connect_port);

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -7,8 +7,34 @@ __attribute__((warn_unused_result))
 int handle_daemon_handshake(int fd);
 __attribute__((warn_unused_result))
 bool negotiate_connection_params(int s, int other_domid, unsigned type,
-        void *cmdline_param, int cmdline_size,
+        const void *cmdline_param, int cmdline_size,
         int *data_domain, int *data_port);
 __attribute__((warn_unused_result))
 bool send_service_connect(int s, const char *conn_ident,
         int connect_domain, int connect_port);
+__attribute__((warn_unused_result))
+int run_qrexec_to_dom0(const struct service_params *svc_params,
+                       int src_domain_id,
+                       const char *src_domain_name,
+                       char *remote_cmdline,
+                       int connection_timeout,
+                       bool exit_with_code);
+struct handshake_params {
+    libvchan_t *data_vchan;
+    struct buffer *stdin_buffer;
+    union {
+        int prepare_ret;
+        int data_protocol_version;
+    };
+    bool remote_send_first;
+    bool exit_with_code;
+    // whether qrexec-client should replace problematic bytes with _ before printing the output
+    bool replace_chars_stdout;
+    bool replace_chars_stderr;
+};
+__attribute__((warn_unused_result))
+int handshake_and_go(struct handshake_params *params);
+__attribute__((warn_unused_result))
+int handle_agent_handshake(libvchan_t *vchan, bool remote_send_first);
+__attribute__((warn_unused_result))
+int prepare_local_fds(struct qrexec_parsed_command *command, struct buffer *stdin_buffer);

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -193,11 +193,12 @@ static int create_qrexec_socket(int domid, const char *domname)
     res = unlink(link_to_socket_name);
     if (res != 0 && !(res == -1 && errno == ENOENT))
         err(1, "unlink(%s)", link_to_socket_name);
+    const char *symlink_target = socket_address + strlen(socket_dir) + 1;
 
     /* When running as root, make the socket accessible; perms on /var/run/qubes still apply */
     umask(0);
-    if (symlink(socket_address, link_to_socket_name)) {
-        PERROR("symlink(%s,%s)", socket_address, link_to_socket_name);
+    if (symlink(symlink_target, link_to_socket_name)) {
+        PERROR("symlink(%s,%s)", symlink_target, link_to_socket_name);
     }
     int fd = get_server_socket(socket_address);
     umask(0077);

--- a/doc/qrexec-policy-daemon.rst
+++ b/doc/qrexec-policy-daemon.rst
@@ -30,4 +30,16 @@ Any possible extensions may be placed on next lines.
 All responses that do not start with `result=allow` or `result=deny` are
 incorrect and will be rejected.
 
-End of response and request is always an empty line.
+End of request is always an empty line.
+Response is always terminated by EOF.
+
+Extensions include:
+
+- `target=`: Name of the target, optionally preceded by `@dispvm:`
+  `@dispvm:` prefix means that this is a disposable VM template and a new disposable VM will be created automatically.
+  In allow responses, ignored if `target_uuid=` is present, required otherwise.
+  Forbidden in deny responses.
+- `autostart=`: `True` to automatically start the VM, `False` to not start it.
+  Anything else is invalid.
+  Required in allow responses, forbidden in deny responses.
+- `requested_target=`: Normalized version of the target domain.

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -38,7 +38,7 @@ test-%: % %_seed_corpus.zip
 	unzip $<_seed_corpus.zip
 	./$< $<_seed_corpus -runs=100000
 
-qrexec_daemon_fuzzer: qrexec_daemon_fuzzer.o fuzz.o $(LIBQREXEC_OBJS) daemon-qrexec-daemon.o
+qrexec_daemon_fuzzer: qrexec_daemon_fuzzer.o fuzz.o $(LIBQREXEC_OBJS) daemon-qrexec-daemon.o daemon-qrexec-daemon-common.o
 
 %_fuzzer: %_fuzzer.o fuzz.o $(LIBQREXEC_OBJS)
 	$(CXX) $(CXXFLAGS) -o $@ $^ $(LIB_FUZZING_ENGINE)

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS += -O1 -fno-omit-frame-pointer -gline-tables-only \
 		-fsanitize-address-use-after-scope -fsanitize=fuzzer
 endif
 
-_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o toml.o
+_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o toml.o process_io.o
 LIBQREXEC_OBJS = $(patsubst %.o,libqrexec-%.o,$(_LIBQREXEC_OBJS))
 
 FUZZERS = qubesrpc_parse_fuzzer qrexec_remote_fuzzer qrexec_daemon_fuzzer

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -138,7 +138,7 @@ static int do_fork_exec(const char *user,
                 abort();
             status = errno;
             while (write(statuspipe[1], &status, sizeof status) <= 0) {}
-            exit(-1);
+            _exit(-1);
         }
         default: {
             close(statuspipe[1]);

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -124,7 +124,6 @@ void *buffer_data(struct buffer *b);
 
 int flush_client_data(int fd, struct buffer *buffer);
 int write_stdin(int fd, const char *data, int len, struct buffer *buffer);
-int fork_and_flush_stdin(int fd, struct buffer *buffer);
 
 /**
  * @brief Execute an already-parsed Qubes RPC command.

--- a/libqrexec/write-stdin.c
+++ b/libqrexec/write-stdin.c
@@ -75,7 +75,7 @@ int write_stdin(int fd, const char *data, int len, struct buffer *buffer)
         ret = write(fd, data + written, len - written);
         if (ret == 0) {
             PERROR("write_stdin: write returns 0 ???");
-            exit(1);
+            abort();
         }
         if (ret == -1) {
             if (errno != EAGAIN)

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -581,9 +581,12 @@ class TestClient(unittest.TestCase):
             self.client.communicate()
             self.client = None
 
-    def connect_daemon(self, domain_name):
+    def connect_daemon(self, domain_id, domain_name):
+        assert isinstance(domain_id, int), "domain ID is first"
+        assert isinstance(domain_name, str), "domain name is second"
         daemon = qrexec.socket_server(
-            os.path.join(self.tempdir, "qrexec.{}".format(domain_name))
+            os.path.join(self.tempdir, "qrexec.{}".format(domain_id)),
+            os.path.join(self.tempdir, "qrexec.{}".format(domain_name)),
         )
         self.addCleanup(daemon.close)
         return daemon
@@ -604,7 +607,7 @@ class TestClient(unittest.TestCase):
         target_domain = 42
         target_port = 513
 
-        target_daemon = self.connect_daemon(target_domain_name)
+        target_daemon = self.connect_daemon(target_domain, target_domain_name)
         self.start_client(["-d", target_domain_name, cmd])
         target_daemon.accept()
         target_daemon.handshake()
@@ -640,7 +643,7 @@ class TestClient(unittest.TestCase):
         target_domain = 42
         target_port = 513
 
-        target_daemon = self.connect_daemon(target_domain_name)
+        target_daemon = self.connect_daemon(target_domain, target_domain_name)
         self.start_client(["-d", target_domain_name, "-l", local_cmd, cmd])
         target_daemon.accept()
         target_daemon.handshake()
@@ -687,8 +690,8 @@ class TestClient(unittest.TestCase):
         target_domain = 42
         target_port = 513
 
-        target_daemon = self.connect_daemon(target_domain_name)
-        src_daemon = self.connect_daemon(src_domain_name)
+        target_daemon = self.connect_daemon(target_domain, target_domain_name)
+        src_daemon = self.connect_daemon(src_domain, src_domain_name)
 
         self.start_client(
             [
@@ -737,7 +740,7 @@ class TestClient(unittest.TestCase):
         src_domain = 43
         src_port = 42
 
-        src_daemon = self.connect_daemon(src_domain_name)
+        src_daemon = self.connect_daemon(src_domain, src_domain_name)
         source = self.connect_source(src_domain, src_port)
 
         self.start_client(

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -930,7 +930,6 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
         self.client.wait()
         self.assertEqual(self.client.returncode, 0)
 
-    @unittest.expectedFailure
     def test_run_dom0_service_socket_no_send_descriptor(self):
         """Socket based service with no service descriptor"""
         config_path = os.path.join(self.tempdir, "rpc-config", "qubes.SocketService+arg")

--- a/qrexec/tests/socket/qrexec.py
+++ b/qrexec/tests/socket/qrexec.py
@@ -135,13 +135,21 @@ def vchan_server(socket_dir, domain, remote_domain, port):
     return socket_server(vchan_socket_path)
 
 
-def socket_server(socket_path):
+def socket_server(socket_path, socket_path_alt=None):
     try:
         os.unlink(socket_path)
     except FileNotFoundError:
         pass
+    if socket_path_alt is not None:
+        assert socket_path_alt[0] == '/', "path not absolute"
+        try:
+            os.unlink(socket_path_alt)
+        except FileNotFoundError:
+            pass
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server.bind(socket_path)
+    if socket_path_alt is not None:
+        os.symlink(socket_path, socket_path_alt)
     server.listen(1)
     return QrexecServer(server)
 


### PR DESCRIPTION
This saves an `execve()`.  It also allows qrexec-daemon to change how it performs a VM -> VM service call without having to change qrexec-client.  During an upgrade, it is possible that qrexec-daemon is newer than qrexec-client, causing the new qrexec-daemon to try to use a calling convention that the old qrexec-client doesn't support.  Doing VM -> VM calls without calling execve() means this cannot happen.  VM -> dom0 and dom0 -> VM calls still use qrexec-client, but VM -> dom0 calls are safe from domain name reuse races as of 654635c2a374272f18bdfe59472a8ae6b51a551e, and the latter do not involve qrexec-daemon at all.

The preceding commits are all either cleanups or bug fixes.