### PR TITLE
Support not passing metadata to socket-based services

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -134,10 +134,12 @@ static int handle_just_exec(struct qrexec_parsed_command *cmd)
 {
     int fdn, pid;
 
+    if (cmd == NULL)
+        return 127;
     switch (pid = fork()) {
         case -1:
             PERROR("fork");
-            return -1;
+            return 127;
         case 0:
             fdn = open("/dev/null", O_RDWR);
             fix_fds(fdn, fdn, fdn);
@@ -271,7 +273,8 @@ static int handle_new_process_common(
             return 0;
         case MSG_EXEC_CMDLINE:
             buffer_init(&stdin_buf);
-            if (execute_parsed_qubes_rpc_command(cmd, &pid, &stdin_fd, &stdout_fd, &stderr_fd, &stdin_buf) < 0) {
+            if (cmd == NULL ||
+                    execute_parsed_qubes_rpc_command(cmd, &pid, &stdin_fd, &stdout_fd, &stderr_fd, &stdin_buf) < 0) {
                 struct msg_header hdr = {
                     .type = MSG_DATA_STDOUT,
                     .len = 0,

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -592,21 +592,13 @@ static void handle_server_exec_request_init(struct msg_header *hdr)
 
         /* load service config only for service requests */
         if (cmd->service_descriptor) {
-            int wait_for_session = 0;
-            char *user = NULL;
-
-            if (load_service_config(cmd, &wait_for_session, &user) < 0) {
+            if (load_service_config_v2(cmd) < 0) {
                 LOG(ERROR, "Could not load config for command %s", buf);
                 return;
             }
 
-            if (user != NULL) {
-                free(cmd->username);
-                cmd->username = user;
-            }
-
             /* "nogui:" prefix has priority */
-            if (!cmd->nogui && wait_for_session && wait_for_session_maybe(cmd)) {
+            if (!cmd->nogui && cmd->wait_for_session && wait_for_session_maybe(cmd)) {
                 /* waiting for session, postpone actual call */
                 int slot_index;
                 for (slot_index = 0; slot_index < MAX_FDS; slot_index++)

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -85,6 +85,7 @@ static const char *fork_server_path = QREXEC_FORK_SERVER_SOCKET;
 static void handle_server_exec_request_do(int type, int connect_domain, int connect_port,
                                           struct qrexec_parsed_command *cmd,
                                           char *cmdline);
+static void terminate_connection(uint32_t domain, uint32_t port);
 
 const bool qrexec_is_fork_server = false;
 
@@ -587,14 +588,16 @@ static void handle_server_exec_request_init(struct msg_header *hdr)
         cmd = parse_qubes_rpc_command(buf, true);
         if (cmd == NULL) {
             LOG(ERROR, "Could not parse command line: %s", buf);
-            return;
+            goto doit;
         }
 
         /* load service config only for service requests */
         if (cmd->service_descriptor) {
             if (load_service_config_v2(cmd) < 0) {
                 LOG(ERROR, "Could not load config for command %s", buf);
-                return;
+                destroy_qrexec_parsed_command(cmd);
+                cmd = NULL;
+                goto doit;
             }
 
             /* "nogui:" prefix has priority */
@@ -620,6 +623,7 @@ static void handle_server_exec_request_init(struct msg_header *hdr)
         }
     }
 
+doit:
     handle_server_exec_request_do(hdr->type, params.connect_domain, params.connect_port, cmd, buf);
     destroy_qrexec_parsed_command(cmd);
     free(buf);
@@ -663,7 +667,7 @@ static void handle_server_exec_request_do(int type,
         return;
     }
 
-    if (!cmd->nogui) {
+    if (cmd != NULL && !cmd->nogui) {
         /* try fork server */
         int child_socket = try_fork_server(type,
                 params.connect_domain, params.connect_port,
@@ -757,18 +761,27 @@ static int find_connection(int pid)
 }
 
 static void release_connection(int id) {
-    struct msg_header hdr;
-    struct exec_params params;
-
-    hdr.type = MSG_CONNECTION_TERMINATED;
-    hdr.len = sizeof(struct exec_params);
-    params.connect_domain = connection_info[id].connect_domain;
-    params.connect_port = connection_info[id].connect_port;
-    if (libvchan_send(ctrl_vchan, &hdr, sizeof(hdr)) != sizeof(hdr))
-        handle_vchan_error("send (MSG_CONNECTION_TERMINATED hdr)");
-    if (libvchan_send(ctrl_vchan, &params, sizeof(params)) != sizeof(params))
-        handle_vchan_error("send (MSG_CONNECTION_TERMINATED data)");
+    terminate_connection(connection_info[id].connect_domain,
+                         connection_info[id].connect_port);
     connection_info[id].pid = 0;
+}
+
+static void terminate_connection(uint32_t domain, uint32_t port) {
+    struct {
+        struct msg_header hdr;
+        struct exec_params params;
+    } data = {
+        .hdr = {
+            .type = MSG_CONNECTION_TERMINATED,
+            .len = sizeof(struct exec_params),
+        },
+        .params = {
+            .connect_domain = domain,
+            .connect_port = port,
+        },
+    };
+    if (libvchan_send(ctrl_vchan, &data, sizeof(data)) != sizeof(data))
+        handle_vchan_error("send (MSG_CONNECTION_TERMINATED)");
 }
 
 static void reap_children(void)

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -213,7 +213,6 @@ static _Noreturn void do_exec(const char *prog, const char *username __attribute
 /* See also qrexec-agent.c:wait_for_session_maybe() */
 static void wait_for_session_maybe(char *cmdline)
 {
-    int wait_for_session = 0;
     struct qrexec_parsed_command *cmd;
     pid_t pid;
     int status;
@@ -228,9 +227,8 @@ static void wait_for_session_maybe(char *cmdline)
     if (!cmd->service_descriptor)
         goto out;
 
-    char *user = NULL;
-    load_service_config(cmd, &wait_for_session, &user);
-    if (!wait_for_session)
+    load_service_config_v2(cmd);
+    if (!cmd->wait_for_session)
         goto out;
 
     pid = fork();

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -1,10 +1,11 @@
-CC=gcc
+CC ?=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
    -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
    -D_GNU_SOURCE $(CFLAGS) \
-   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations
+   -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations \
+   -fno-delete-null-pointer-checks
 
 override LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
 

--- a/libqrexec/buffer.c
+++ b/libqrexec/buffer.c
@@ -23,6 +23,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 #include "libqrexec-utils.h"
 
 #define BUFFER_LIMIT 50000000
@@ -79,6 +80,7 @@ void buffer_append(struct buffer *b, const char *data, int len)
 {
     int newsize;
     char *qdata;
+    assert(data != NULL && "NULL data");
     if (b->buflen < 0 || b->buflen > BUFFER_LIMIT) {
         LOG(ERROR, "buffer_append buflen %d", len);
         exit(1);
@@ -91,7 +93,9 @@ void buffer_append(struct buffer *b, const char *data, int len)
         return;
     newsize = len + b->buflen;
     qdata = limited_malloc(len + b->buflen);
-    memcpy(qdata, b->data, (size_t)b->buflen);
+    if (b->data != 0) {
+        memcpy(qdata, b->data, (size_t)b->buflen);
+    }
     memcpy(qdata + b->buflen, data, (size_t)len);
     buffer_free(b);
     b->buflen = newsize;

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -36,6 +36,7 @@
 #include <fcntl.h>
 #include "qrexec.h"
 #include "libqrexec-utils.h"
+#include "private.h"
 
 static do_exec_t *exec_func = NULL;
 void register_exec_func(do_exec_t *func) {

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -252,11 +252,10 @@ static int find_file(
     }
     return -1;
 }
-int load_service_config(const struct qrexec_parsed_command *cmd,
-                        int *wait_for_session, char **user) {
-    assert(cmd->service_descriptor);
-    assert(*user == NULL);
 
+static int load_service_config_raw(struct qrexec_parsed_command *cmd,
+                                   char **user)
+{
     const char *config_path = getenv("QUBES_RPC_CONFIG_PATH");
     if (!config_path)
         config_path = QUBES_RPC_CONFIG_PATH;
@@ -270,9 +269,29 @@ int load_service_config(const struct qrexec_parsed_command *cmd,
                         config_full_path, sizeof(config_full_path), NULL);
     if (ret < 0)
         return 0;
-
-    return qubes_toml_config_parse(config_full_path, wait_for_session, user);
+    return qubes_toml_config_parse(config_full_path, &cmd->wait_for_session, user);
 }
+
+int load_service_config_v2(struct qrexec_parsed_command *cmd) {
+    assert(cmd->service_descriptor);
+    char *tmp_user = NULL;
+    int res = load_service_config_raw(cmd, &tmp_user);
+    if (res >= 0 && tmp_user != NULL) {
+        free(cmd->username);
+        cmd->username = tmp_user;
+    }
+    return res;
+}
+
+int load_service_config(struct qrexec_parsed_command *cmd,
+                        int *wait_for_session, char **user) {
+    int rc = load_service_config_raw(cmd, user);
+    if (rc >= 0) {
+        *wait_for_session = cmd->wait_for_session;
+    }
+    return rc;
+}
+
 
 struct qrexec_parsed_command *parse_qubes_rpc_command(
     const char *cmdline, bool strip_username) {

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -303,7 +303,6 @@ void qrexec_log(int level, int errnoval, const char *file, int line,
                 const char *func, const char *fmt, ...) __attribute__((format(printf, 6, 7)));
 
 void setup_logging(const char *program_name);
-int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user);
 
 /**
  * Make an Admin API call to qubesd.  The returned buffer must be released by

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -79,6 +79,9 @@ struct qrexec_parsed_command {
 
     /* Should a session be waited for? */
     bool wait_for_session;
+
+    /* For socket-based services: Should the service descriptor be sent? */
+    bool send_service_descriptor;
 };
 
 /* Parse a command, return NULL on failure. Uses cmd->cmdline

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -52,7 +52,8 @@ struct buffer {
 struct qrexec_parsed_command {
     const char *cmdline;
 
-    /* Username ("user", NULL when strip_username is false) */
+    /* Username ("user", NULL when strip_username is false).
+     * Always safe to pass to free(). */
     char *username;
 
     /* Override to disable "wait for session" */
@@ -75,6 +76,9 @@ struct qrexec_parsed_command {
 
     /* Source domain (the part after service name). */
     char *source_domain;
+
+    /* Should a session be waited for? */
+    bool wait_for_session;
 };
 
 /* Parse a command, return NULL on failure. Uses cmd->cmdline
@@ -89,9 +93,13 @@ void destroy_qrexec_parsed_command(struct qrexec_parsed_command *cmd);
  *  1  - config successfuly loaded
  *  0  - config not found
  *  -1 - other error
+ *
+ * Deprecated, use load_service_config_v2() instead.
  */
-int load_service_config(const struct qrexec_parsed_command *cmd_name,
-                        int *wait_for_session, char **user);
+int load_service_config(struct qrexec_parsed_command *cmd_name,
+                        int *wait_for_session, char **user)
+    __attribute__((deprecated("use load_service_config_v2() instead")));
+int load_service_config_v2(struct qrexec_parsed_command *cmd);
 
 typedef void (do_exec_t)(const char *cmdline, const char *user);
 void register_exec_func(do_exec_t *func);

--- a/libqrexec/private.h
+++ b/libqrexec/private.h
@@ -1,2 +1,2 @@
 #include <stdbool.h>
-int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user);
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user);

--- a/libqrexec/private.h
+++ b/libqrexec/private.h
@@ -1,2 +1,2 @@
 #include <stdbool.h>
-int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user);
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user, bool *skip_service_descriptor);

--- a/libqrexec/private.h
+++ b/libqrexec/private.h
@@ -1,0 +1,2 @@
+#include <stdbool.h>
+int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user);

--- a/libqrexec/toml.c
+++ b/libqrexec/toml.c
@@ -7,6 +7,7 @@
 #include <limits.h>
 
 #include "libqrexec-utils.h"
+#include "private.h"
 
 // A trivial parser for a subset of TOML
 static bool qubes_isspace(unsigned char c) {

--- a/libqrexec/toml.c
+++ b/libqrexec/toml.c
@@ -171,7 +171,7 @@ static void toml_value_free(union toml_data *value, enum toml_type ty) {
     }
 }
 
-int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user)
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user, bool *send_service_descriptor)
 {
     int result = -1; /* assume problem */
     FILE *config_file = fopen(config_full_path, "re");
@@ -186,7 +186,9 @@ int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session
     ssize_t signed_linelen;
     bool seen_wait_for_session = false;
     bool seen_user = false;
+    bool seen_skip_service_descriptor = false;
     *wait_for_session = 0;
+    *send_service_descriptor = true;
 #define CHECK_DUP_KEY(v) do {                                               \
     if (toml_check_dup_key(&(v), config_full_path, lineno, current_line)) { \
         toml_value_free(&value, ty);                                        \
@@ -288,6 +290,10 @@ int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session
                 CHECK_TYPE(TOML_TYPE_BOOL, "wait-for-session");
                 *wait_for_session = value.boolean;
             }
+        } else if (strcmp(current_line, "skip-service-descriptor") == 0) {
+            CHECK_DUP_KEY(seen_skip_service_descriptor);
+            CHECK_TYPE(TOML_TYPE_BOOL, "skip-service-descriptor");
+            *send_service_descriptor = !value.boolean;
         } else if (strcmp(current_line, "force-user") == 0) {
             CHECK_DUP_KEY(seen_user);
             CHECK_TYPE(TOML_TYPE_STRING, "user name or user ID");

--- a/libqrexec/toml.c
+++ b/libqrexec/toml.c
@@ -132,7 +132,46 @@ static bool qubes_is_key_byte(unsigned char c) {
     }
 }
 
-int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session, char **user)
+static void toml_invalid_type(enum toml_type ty, const char *file, size_t lineno, const char *msg)
+{
+    const char *bad_type;
+    switch (ty) {
+        case TOML_TYPE_INVALID:
+            bad_type = "<invalid value>";
+            break;
+        case TOML_TYPE_BOOL:
+            bad_type = "Boolean";
+            break;
+        case TOML_TYPE_INTEGER:
+            bad_type = "Integer";
+            break;
+        case TOML_TYPE_STRING:
+            bad_type = "String";
+            break;
+        default:
+            abort();
+    }
+    LOG(ERROR, "%s:%zu: %s not valid for %s", file, lineno, bad_type, msg);
+}
+
+static bool toml_check_dup_key(bool *seen_already, const char *file, size_t lineno, const char *msg)
+{
+    if (*seen_already) {
+        LOG(ERROR, "%s:%zu: Key %s already seen", file, lineno, msg);
+        return true;
+    }
+    *seen_already = true;
+    return false;
+}
+
+static void toml_value_free(union toml_data *value, enum toml_type ty) {
+    if (ty == TOML_TYPE_STRING) {
+        free(value->string);
+        value->string = NULL;
+    }
+}
+
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user)
 {
     int result = -1; /* assume problem */
     FILE *config_file = fopen(config_full_path, "re");
@@ -147,6 +186,21 @@ int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session,
     ssize_t signed_linelen;
     bool seen_wait_for_session = false;
     bool seen_user = false;
+    *wait_for_session = 0;
+#define CHECK_DUP_KEY(v) do {                                               \
+    if (toml_check_dup_key(&(v), config_full_path, lineno, current_line)) { \
+        toml_value_free(&value, ty);                                        \
+        goto bad;                                                           \
+    }                                                                       \
+} while (0);
+#define CHECK_TYPE(v, msg) do {                                             \
+    if ((v) != ty) {                                                        \
+        toml_invalid_type(v, config_full_path, lineno, msg);                \
+        toml_value_free(&value, ty);                                        \
+        goto bad;                                                           \
+    }                                                                       \
+} while (0);
+
     while ((signed_linelen = getline(&current_line, &bufsize, config_file)) != -1) {
         lineno++;
         /* Other negative values are invalid.  If nothing at all is read that means EOF. */
@@ -218,55 +272,30 @@ int qubes_toml_config_parse(const char *config_full_path, int *wait_for_session,
         current_line[key_len] = '\0';
         union toml_data value;
         enum toml_type ty = parse_toml_value(config_full_path, lineno, key_cursor, &value);
+        if (ty == TOML_TYPE_INVALID)
+            goto bad;
 
         if (strcmp(current_line, "wait-for-session") == 0) {
-            if (seen_wait_for_session) {
-                LOG(ERROR, "%s:%zu: Key '%s' appears more than once", config_full_path, lineno, current_line);
-                goto bad;
-            }
-            seen_wait_for_session = true;
-            if (ty == TOML_TYPE_BOOL) {
-                *wait_for_session = (int)value.boolean;
-                continue;
-            } else if (ty == TOML_TYPE_INTEGER) {
+            CHECK_DUP_KEY(seen_wait_for_session);
+            if (ty == TOML_TYPE_INTEGER) {
                 if (value.integer < 2) {
                     *wait_for_session = (int)value.integer;
                     continue;
                 }
-                LOG(ERROR, "Integer value %llu used when a boolean was expected", value.integer);
-            } else if (ty == TOML_TYPE_STRING) {
-                LOG(ERROR, "String value '%s' not valid for 'wait-for-session'", value.string);
-                free(value.string);
-                value.string = NULL;
+                LOG(ERROR, "%s:%zu: Unsupported integer value %llu for boolean", config_full_path, lineno, value.integer);
+                goto bad;
+            } else {
+                CHECK_TYPE(TOML_TYPE_BOOL, "wait-for-session");
+                *wait_for_session = value.boolean;
             }
         } else if (strcmp(current_line, "force-user") == 0) {
-            if (seen_user) {
-                LOG(ERROR, "%s:%zu: Key '%s' appears more than once", config_full_path, lineno, current_line);
-                goto bad;
-            }
-            seen_user = true;
-            char *bad_type;
-            switch (ty) {
-            case TOML_TYPE_INVALID:
-                goto bad;
-            case TOML_TYPE_BOOL:
-                bad_type = "Boolean";
-                break;
-            case TOML_TYPE_INTEGER:
-                bad_type = "Integer";
-                break;
-            case TOML_TYPE_STRING:
-                *user = value.string;
-                continue;
-            default:
-                abort();
-            }
-            LOG(ERROR, "%s:%zu: %s not valid for user name or user ID", config_full_path, lineno, bad_type);
+            CHECK_DUP_KEY(seen_user);
+            CHECK_TYPE(TOML_TYPE_STRING, "user name or user ID");
+            *user = value.string;
         } else {
             LOG(ERROR, "%s:%zu: Unsupported key %s", config_full_path, lineno, current_line);
-            continue;
+            toml_value_free(&value, ty);
         }
-        goto bad;
     }
 
     result = 1;

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -623,16 +623,20 @@ sleep 1
             f.write("end\n")
             f.flush()
 
+        messages = []
         received_data = b""
         while len(received_data) < data_size:
             message_type, message = target.recv_message()
-            self.assertEqual(message_type, qrexec.MSG_DATA_STDOUT)
-            received_data += message
+            if message_type != qrexec.MSG_DATA_STDOUT:
+                messages.append((message_type, message))
+            else:
+                self.assertEqual(message_type, qrexec.MSG_DATA_STDOUT)
+                received_data += message
 
         self.assertEqual(len(received_data), data_size)
         self.assertEqual(received_data, data)
 
-        messages = target.recv_all_messages()
+        messages += target.recv_all_messages()
         self.assertListEqual(
             util.sort_messages(messages),
             [

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -759,10 +759,10 @@ echo "wait for session: remote domain: $QREXEC_REMOTE_DOMAIN" >{}
             "rpc",
             "qubes.Service",
             """\
-        #!/bin/sh
-        read input
-        cat {}
-        echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
+#!/bin/sh
+cat {}
+read input
+echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
 """.format(
                 log
             ),
@@ -774,16 +774,16 @@ echo "wait for session: remote domain: $QREXEC_REMOTE_DOMAIN" >{}
 
         cmd = "QUBESRPC qubes.Service+arg src_domain name src_domain"
         source = self.connect_service_request(cmd)
+        self.assertEqual(source.recv_message(), (
+            qrexec.MSG_DATA_STDOUT,
+            b"wait for session: remote domain: src_domain\n",
+        ))
 
         source.send_message(qrexec.MSG_DATA_STDIN, b"stdin data\n")
         source.send_message(qrexec.MSG_DATA_STDIN, b"")
         self.assertEqual(
             source.recv_all_messages(),
             [
-                (
-                    qrexec.MSG_DATA_STDOUT,
-                    b"wait for session: remote domain: src_domain\n",
-                ),
                 (
                     qrexec.MSG_DATA_STDOUT,
                     b"arg: arg, remote domain: src_domain, "

--- a/qrexec/tests/socket/qrexec.py
+++ b/qrexec/tests/socket/qrexec.py
@@ -54,7 +54,10 @@ class QrexecClient:
     def recvall(self, data_len):
         data = b""
         while len(data) < data_len:
-            res = self.conn.recv(data_len - len(data))
+            try:
+                res = self.conn.recv(data_len - len(data))
+            except ConnectionResetError:
+                return data
             if not res:
                 return data
             data += res

--- a/run-tests
+++ b/run-tests
@@ -17,4 +17,6 @@ fi
 
 set -x
 
-python3 -m coverage run -m pytest -o python_files=*.py -v qrexec/tests "$@"
+if [[ "$#" = 0 ]]; then set -- -v qrexec/tests; fi
+
+python3 -m coverage run -m pytest -o 'python_files=*.py' "$@"

--- a/run-tests
+++ b/run-tests
@@ -5,8 +5,18 @@ if command -v dnf >/dev/null; then
     sudo dnf install python3dist\({coverage,pytest,gbulb,pyinotify,pytest-asyncio}\) || :
 fi
 if pkg-config vchan-socket; then
-    export CFLAGS="--coverage -DCOVERAGE"
-    export LDFLAGS=--coverage
+    if [[ -n "${USE_ASAN-}" ]]; then
+        export CFLAGS=-fsanitize=address,undefined
+        export LDFLAGS=-fsanitize=address,undefined
+        # MUST use clang here.  GCC causes random SIGSEGV crashes
+        # when ASAN and UBSAN is in use.  Release build (no sanitizers)
+        # works fine.
+        export CC=clang
+        export ASAN_OPTIONS=leak_check_at_exit=0
+    else
+        export CFLAGS="--coverage -DCOVERAGE"
+        export LDFLAGS=--coverage
+    fi
     make -C libqrexec BACKEND_VMM=socket clean all
     make -C agent BACKEND_VMM=socket clean all
     make -C daemon BACKEND_VMM=socket clean all


### PR DESCRIPTION
This makes it easier to implement socket-based services that do not
require the metadata.  This avoids having to use a slow executable-based
service or write a custom wrapper.

Fixes: https://github.com/QubesOS/qubes-issues/issues/9036

Edit: This PR now also fixes https://github.com/QubesOS/qubes-issues/issues/9073.  Furthermore, the first four commits fix multiple bugs in the test suite, and the fifth and sixth are purely test suite enhancements.