### PR TITLE
Stop using qubes-rpc-multiplexer

### DIFF
--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -29,7 +29,7 @@
 
 int handle_handshake(libvchan_t *ctrl);
 void handle_vchan_error(const char *op);
-_Noreturn void do_exec(const char *cmd, const char *user);
+_Noreturn void do_exec(const char *prog, const char *cmd, const char *user);
 /* call before fork() for service handling process (either end) */
 void prepare_child_env(void);
 

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -43,7 +43,7 @@ _Noreturn void handle_vchan_error(const char *op)
     exit(1);
 }
 
-_Noreturn void do_exec(const char *cmd __attribute__((unused)), char const* user __attribute__((__unused__))) {
+_Noreturn void do_exec(const char *prog __attribute__((unused)), const char *cmd __attribute__((unused)), char const* user __attribute__((__unused__))) {
     LOG(ERROR, "BUG: do_exec function shouldn't be called!");
     abort();
 }

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -44,8 +44,11 @@ void do_exec(const char *prog, const char *cmd, const char *user __attribute__((
     signal(SIGCHLD, SIG_DFL);
     signal(SIGPIPE, SIG_DFL);
 
-    /* Call QUBESRPC if requested.  This code already runs in a login session. */
-    exec_qubes_rpc_if_requested2(prog, cmd, environ, false);
+    /* call QUBESRPC if requested */
+    if (prog != NULL) {
+        /* Already in login session. */
+        exec_qubes_rpc2(prog, cmd, environ, false);
+    }
 
     /* otherwise, pass it to shell */
     shell = getenv("SHELL");

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -37,15 +37,15 @@
 extern char **environ;
 const bool qrexec_is_fork_server = true;
 
-void do_exec(const char *cmd, const char *user __attribute__((unused)))
+void do_exec(const char *prog, const char *cmd, const char *user __attribute__((unused)))
 {
     char *shell;
 
     signal(SIGCHLD, SIG_DFL);
     signal(SIGPIPE, SIG_DFL);
 
-    /* call QUBESRPC if requested */
-    exec_qubes_rpc_if_requested(cmd, environ);
+    /* Call QUBESRPC if requested.  This code already runs in a login session. */
+    exec_qubes_rpc_if_requested2(prog, cmd, environ, false);
 
     /* otherwise, pass it to shell */
     shell = getenv("SHELL");

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -134,7 +134,7 @@ static void parse_connect(char *str, char **request_id,
     if (token == NULL)
         goto bad_c_param;
     if ((size_t)(token - str) >= sizeof(struct service_params))
-        errx(1, "Invalid -c parameter (request_id too long, max %zu)\n",
+        errx(1, "Invalid -c parameter (request_id too long, max %zu)",
              sizeof(struct service_params)-1);
     *token = 0;
     *request_id = str;

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -66,11 +66,13 @@ static _Noreturn void do_exec(const char *prog,
                               const char *cmdline,
                               const char *username __attribute__((unused)))
 {
-    /* Avoid calling RPC command through shell.
-     * Qrexec-client is always in a login session. */
-    exec_qubes_rpc_if_requested2(prog, cmdline, environ, false);
+    /* avoid calling RPC service through shell */
+    if (prog) {
+        /* qrexec-client is always in a login session. */
+        exec_qubes_rpc2(prog, cmdline, environ, false);
+    }
 
-    /* if above haven't executed RPC command, pass it to shell */
+    /* if above haven't executed RPC service, pass it to shell */
     execl("/bin/bash", "bash", "-c", cmdline, NULL);
     PERROR("exec bash");
     exit(1);
@@ -326,11 +328,8 @@ int main(int argc, char **argv)
                 assert(command->username == NULL);
                 assert(command->command);
                 /* qrexec-client is always in a login session. */
-                exec_qubes_rpc_if_requested2(buf.data, command->command, environ, false);
-                /* not reached, so fall through to crash */
-                assert(false);
-                rc = QREXEC_EXIT_PROBLEM;
-                break;
+                exec_qubes_rpc2(buf.data, command->command, environ, false);
+                /* not reached */
             default:
                 assert(false);
                 rc = QREXEC_EXIT_PROBLEM;

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -62,13 +62,16 @@ static void set_remote_domain(const char *src_domain_name) {
 }
 
 /* called from do_fork_exec */
-static _Noreturn void do_exec(const char *prog, const char *username __attribute__((unused)))
+static _Noreturn void do_exec(const char *prog,
+                              const char *cmdline,
+                              const char *username __attribute__((unused)))
 {
-    /* avoid calling qubes-rpc-multiplexer through shell */
-    exec_qubes_rpc_if_requested(prog, environ);
+    /* Avoid calling RPC command through shell.
+     * Qrexec-client is always in a login session. */
+    exec_qubes_rpc_if_requested2(prog, cmdline, environ, false);
 
-    /* if above haven't executed qubes-rpc-multiplexer, pass it to shell */
-    execl("/bin/bash", "bash", "-c", prog, NULL);
+    /* if above haven't executed RPC command, pass it to shell */
+    execl("/bin/bash", "bash", "-c", cmdline, NULL);
     PERROR("exec bash");
     exit(1);
 }

--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -364,7 +364,7 @@ static void sigchld_handler(int x __attribute__((__unused__)))
 }
 
 /* See also qrexec-agent.c:wait_for_session_maybe() */
-static bool wait_for_session_maybe(struct qrexec_parsed_command *cmd)
+bool wait_for_session_maybe(struct qrexec_parsed_command *cmd)
 {
     pid_t pid;
     int status;

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -147,3 +147,7 @@ bool qrexec_execute_vm(const char *target, bool autostart, int remote_domain_id,
 extern int local_stdin_fd;
 __attribute__((warn_unused_result))
 bool target_refers_to_dom0(const char *target);
+
+/** Wait for a session if needed. */
+__attribute__((warn_unused_result))
+bool wait_for_session_maybe(struct qrexec_parsed_command *cmd);

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1131,14 +1131,16 @@ static enum policy_response connect_daemon_socket(
 }
 
 /* called from do_fork_exec */
-static _Noreturn void do_exec(const char *prog, const char *username __attribute__((unused)))
+static _Noreturn void do_exec(const char *prog, const char *cmd, const char *username __attribute__((unused)))
 {
-    /* avoid calling qubes-rpc-multiplexer through shell */
-    exec_qubes_rpc_if_requested(prog, environ);
+    /* Avoid calling RPC command through shell.
+     * Qrexec-daemon is always in a login session already. */
+    exec_qubes_rpc_if_requested2(prog, cmd, environ, true);
 
-    /* if above haven't executed qubes-rpc-multiplexer, pass it to shell */
-    execl("/bin/bash", "bash", "-c", prog, NULL);
+    /* if above haven't executed RPC command, pass it to shell */
+    execl("/bin/bash", "bash", "-c", cmd, NULL);
     PERROR("exec bash");
+    /* treat ENOENT as "problem" because bash should always exist */
     _exit(QREXEC_EXIT_PROBLEM);
 }
 

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1133,9 +1133,11 @@ static enum policy_response connect_daemon_socket(
 /* called from do_fork_exec */
 static _Noreturn void do_exec(const char *prog, const char *cmd, const char *username __attribute__((unused)))
 {
-    /* Avoid calling RPC command through shell.
-     * Qrexec-daemon is always in a login session already. */
-    exec_qubes_rpc_if_requested2(prog, cmd, environ, true);
+    /* avoid calling RPC command through shell */
+    if (prog) {
+        /* qrexec-daemon is always in a login session already */
+        exec_qubes_rpc2(prog, cmd, environ, false);
+    }
 
     /* if above haven't executed RPC command, pass it to shell */
     execl("/bin/bash", "bash", "-c", cmd, NULL);

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Homepage: https://www.qubes-os.org
 Package: qubes-core-qrexec
 Architecture: any
 Depends:
- libqrexec-utils2 (= ${binary:Version}),
+ libqrexec-utils4 (= ${binary:Version}),
  python3-qrexec,
  ${shlibs:Depends},
  ${misc:Depends}
@@ -36,7 +36,7 @@ Description: Qubes qrexec agent
  Agent part of Qubes RPC system. A daemon responsible for starting processes as
  requested by dom0 or other VMs, according to dom0-enforced policy.
 
-Package: libqrexec-utils2
+Package: libqrexec-utils4
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Breaks: qubes-utils (<< 3.1.4)
@@ -47,7 +47,7 @@ Description: Library of common functions of qrexec agent and daemon
 Package: libqrexec-utils-dev
 Architecture: any
 Section: libdevel
-Depends: libqrexec-utils2 (= ${binary:Version}), ${misc:Depends}
+Depends: libqrexec-utils4 (= ${binary:Version}), ${misc:Depends}
 Breaks: qubes-utils (<< 3.1.4)
 Replaces: qubes-utils (<< 3.1.4)
 Description: Development headers for libqrexec-utils

--- a/debian/libqrexec-utils2.install
+++ b/debian/libqrexec-utils2.install
@@ -1,1 +1,0 @@
-usr/lib/libqrexec-utils.so.3*

--- a/debian/libqrexec-utils2.shlibs
+++ b/debian/libqrexec-utils2.shlibs
@@ -1,1 +1,0 @@
-libqrexec-utils 3 libqrexec-utils2 (>= 4.1.0)

--- a/debian/libqrexec-utils4.install
+++ b/debian/libqrexec-utils4.install
@@ -1,0 +1,1 @@
+usr/lib/libqrexec-utils.so.4*

--- a/debian/libqrexec-utils4.shlibs
+++ b/debian/libqrexec-utils4.shlibs
@@ -1,0 +1,1 @@
+libqrexec-utils 4 libqrexec-utils4 (>=4.2.18)

--- a/doc/execution.rst
+++ b/doc/execution.rst
@@ -197,6 +197,23 @@ between service types is mostly invisible to callers.
    with ``force-user=`` in the configuration file.  The username must be a string
    user due to PAM limitations.
 
+   If a non-empty string is passed as the service argument, it is passed as the
+   first argument to the service.  The service environment is modified as follows:
+
+   1. All environment variables with names starting with ``QREXEC`` are stripped.
+   2. ``QREXEC_REMOTE_DOMAIN`` is set to the name of the calling VM.
+   3. ``QREXEC_SERVICE_FULL_NAME`` is set to the full name of the service,
+      including the argument if any.
+   4. If the service *is not* running in dom0, ``QREXEC_REQUESTED_TARGET_TYPE`` is
+      set to an empty value.
+   5. If the service *is* running in dom0, and the requested target starts with ``@``,
+      ``QREXEC_REQUESTED_TARGET_TYPE`` is set to ``keyword`` and
+      ``QREXEC_REQUESTED_TARGET_KEYWORD`` is set to the requested target with the
+      leading ``@`` removed.
+   6. If the service *is* running in dom0, and the requested target *does not* start with ``@``,
+      ``QREXEC_REQUESTED_TARGET_TYPE`` is set to ``name`` and
+      ``QREXEC_REQUESTED_TARGET`` is set to the requested target.
+
 2. Socket-based services.  These are ``AF_UNIX`` stream sockets on the filesystem.
    Data passed via stdin will be written to the socket, and data from the socket will
    will be written to stdout.

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -22,7 +22,7 @@ endif
 
 
 all: libqrexec-utils.so
-libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o toml.o vchan_timeout.o
+libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o toml.o open_logger.o vchan_timeout.o
 	$(CC) $(LDFLAGS) -Wl,-soname,$@ -o $@ $^ $(VCHANLIBS)
 
 libqrexec-utils.so: libqrexec-utils.so.$(SO_VER)

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -10,7 +10,7 @@ CFLAGS += -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
 
 LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
 
-SO_VER=3
+SO_VER=4
 VCHANLIBS := $(shell pkg-config --libs vchan)
 LIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include

--- a/libqrexec/buffer.c
+++ b/libqrexec/buffer.c
@@ -35,12 +35,12 @@ static char *limited_malloc(int len)
         (total_mem > BUFFER_LIMIT) || (len <= 0))
     {
         LOG(ERROR, "attempt to allocate >BUFFER_LIMIT");
-        exit(1);
+        abort();
     }
     ret = malloc((size_t)len);
     if (!ret) {
         PERROR("malloc");
-        exit(1);
+        abort();
     }
     return ret;
 }
@@ -83,11 +83,11 @@ void buffer_append(struct buffer *b, const char *data, int len)
     assert(data != NULL && "NULL data");
     if (b->buflen < 0 || b->buflen > BUFFER_LIMIT) {
         LOG(ERROR, "buffer_append buflen %d", len);
-        exit(1);
+        abort();
     }
     if (len < 0 || len > BUFFER_LIMIT) {
         LOG(ERROR, "buffer_append %d", len);
-        exit(1);
+        abort();
     }
     if (len == 0)
         return;
@@ -108,7 +108,7 @@ void buffer_remove(struct buffer *b, int len)
     char *qdata = NULL;
     if (len < 0 || len > b->buflen) {
         LOG(ERROR, "buffer_remove %d/%d", len, b->buflen);
-        exit(1);
+        abort();
     }
     newsize = b->buflen - len;
     if (newsize > 0) {

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -36,6 +36,7 @@
 #include <netdb.h>
 #include <unistd.h>
 #include <fcntl.h>
+
 #include "qrexec.h"
 #include "libqrexec-utils.h"
 #include "private.h"
@@ -59,169 +60,158 @@ static bool should_strip_env_var(const char *var)
            !STARTS_WITH_LITERAL(rest, "_AGENT_PID=");
 }
 
-void exec_qubes_rpc_if_requested2(const char *program, const char *cmd, char *const envp[],
-                                  bool use_shell) {
+void exec_qubes_rpc2(const char *program, const char *cmd, char *const envp[],
+                     bool use_shell) {
+    assert(cmd);
     /* avoid calling RPC service through shell */
-    if (program) {
-        assert(program);
-        char *prog_copy;
-        char *tok, *savetok;
-        const char *argv[10];
-        size_t i = 0;
+    char *prog_copy;
+    char *tok, *savetok;
+    const char *argv[10];
+    size_t i = 0;
 #define MAX_ADDED_ENV_VARS 5
-        size_t const extra_env_vars = MAX_ADDED_ENV_VARS;
-        size_t env_amount = extra_env_vars;
+    size_t const extra_env_vars = MAX_ADDED_ENV_VARS;
+    size_t env_amount = extra_env_vars;
 
-        if (strncmp(cmd, RPC_REQUEST_COMMAND " ", RPC_REQUEST_COMMAND_LEN + 1) != 0) {
-            LOG(ERROR, "program != NULL, but '%s' does not start with '%s '",
-                cmd, RPC_REQUEST_COMMAND " ");
-            assert(!"Invalid command");
-            _exit(QREXEC_EXIT_PROBLEM);
-        }
-
-        for (char *const *env = envp; *env; ++env) {
-            // Set this 0 to 1 if adding new variable settings below,
-            // to ensure that MAX_ADDED_ENV_VARS is correct.
-            if (0 && should_strip_env_var(*env))
-                continue;
-            env_amount++;
-        }
-#define EXTEND(...)                                             \
-        do {                                                    \
-            if (iterator >= env_amount)                         \
-                abort();                                        \
-            if (asprintf(&buf[iterator++], __VA_ARGS__) < 0)    \
-                goto bad_asprintf;                              \
-        } while (0)
-#define EXTEND_RAW(arg)                                         \
-        do {                                                    \
-            if (iterator >= env_amount)                         \
-                abort();                                        \
-            buf[iterator++] = (arg);                            \
-        } while (0)
-
-        char **buf = calloc(env_amount + 1, sizeof(char *));
-        if (buf == NULL) {
-            LOG(ERROR, "calloc(%zu, %zu) failed: %m", env_amount, sizeof(char *));
-            _exit(QREXEC_EXIT_PROBLEM);
-        }
-        size_t iterator = 0;
-        for (char *const *env = envp; *env; ++env) {
-            if (!should_strip_env_var(*env)) {
-                EXTEND_RAW(*env);
-            }
-        }
-
-        prog_copy = strdup(cmd + RPC_REQUEST_COMMAND_LEN + 1);
-        if (!prog_copy) {
-            PERROR("strdup");
-            _exit(QREXEC_EXIT_PROBLEM);
-        }
-
-        argv[i++] = program;
-        tok=strtok_r(prog_copy, " ", &savetok);
-        while (tok != NULL) {
-            if (i >= sizeof(argv)/sizeof(argv[0])) {
-                LOG(ERROR, "Too many arguments to %s", RPC_REQUEST_COMMAND);
-                _exit(QREXEC_EXIT_PROBLEM);
-            }
-            argv[i++] = tok;
-            tok = strtok_r(NULL, " ", &savetok);
-        }
-
-        if (program[0] != '/') {
-            LOG(ERROR, "Program to execute not absolute path");
-            _exit(QREXEC_EXIT_PROBLEM);
-        }
-        if (i != 3 && i != 5) {
-            LOG(ERROR, "invalid number of arguments: %zu", i);
-            _exit(QREXEC_EXIT_PROBLEM);
-        }
-        const char *full_name = argv[1];
-        const char *remote_domain = argv[2];
-        const char *p = strchr(argv[1], '+');
-
-        // Change the 1 to a 0 to test the shell script generator.
-        if (!use_shell && 1) {
-            if (i == 5) {
-                EXTEND("QREXEC_REQUESTED_TARGET_TYPE=%s", argv[3]);
-                if (strcmp(argv[3], "name") == 0) {
-                    EXTEND("QREXEC_REQUESTED_TARGET=%s", argv[4]);
-                } else if (strcmp(argv[3], "keyword") == 0) {
-                    EXTEND("QREXEC_REQUESTED_TARGET_KEYWORD=%s", argv[4]);
-                } else {
-                    // requested target type unknown or not given, ignore
-                }
-            } else {
-                EXTEND_RAW("QREXEC_REQUESTED_TARGET_TYPE=");
-            }
-            EXTEND("QREXEC_SERVICE_FULL_NAME=%s", full_name);
-            EXTEND("QREXEC_REMOTE_DOMAIN=%s", remote_domain);
-            argv[1] = NULL;
-            if (p != NULL) {
-                EXTEND("QREXEC_SERVICE_ARGUMENT=%s", p + 1);
-                if (p[1] != '\0') {
-                    argv[1] = p + 1;
-                    argv[2] = NULL;
-                }
-            }
-            assert(iterator <= env_amount);
-            buf[iterator] = NULL;
-            execve(program, (char *const *)argv, buf);
-            _exit(errno == ENOENT ? QREXEC_EXIT_SERVICE_NOT_FOUND : QREXEC_EXIT_PROBLEM);
-        }
-
-        // Generate a shell command and call it with the correct arguments.
-        // Note that is_name and is_keyword are mutually exclusive.
-        bool is_name = i == 5 && strcmp(argv[3], "name") == 0;
-        bool is_keyword = i == 5 && strcmp(argv[3], "keyword") == 0;
-        const char *requested_target = i == 5 ? argv[4] : NULL;
-        argv[0] = "/bin/sh";
-        argv[1] = "-lc";
-        // Build a shell script that emulates the old multiplexer.
-        // The shell script is only built from string literals,
-        // never data from the provided command.  Reviewers are
-        // invited to check that the produced script is always
-        // valid no matter what the inputs are.  To improve
-        // readability and maintainability, separating whitespace
-        // is included in the format string, so the arguments do
-        // not need to include it.  This means that the produced
-        // script might have unnecessary whitespace, but this is
-        // harmless.
-        if (asprintf((char **)(argv + 2),
-                    // Unset the variables in case the user's shell init code did something weird,
-                    // like mark them read-only or make them an array.
-                    // Use set -e in case there is a problem.  Note that sh -el does not work
-                    // because the startup files are not compatible with -e.
-                    "set -e\n"
-                    "unset QREXEC_SERVICE_FULL_NAME QREXEC_REMOTE_DOMAIN QREXEC_REQUESTED_TARGET_TYPE "
-                    "QREXEC_SERVICE_ARGUMENT QREXEC_REQUESTED_TARGET QREXEC_REQUESTED_TARGET_KEYWORD\n"
-                    "export \"QREXEC_SERVICE_FULL_NAME=$2\" \"QREXEC_REMOTE_DOMAIN=$3\" QREXEC_REQUESTED_TARGET_TYPE=%s %s\n"
-                    // This could just be written as ${4:+"$4"}, which works just as well.
-                    // I decided to make the C code more complicated so the shell has less work
-                    // to do.
-                    "exec \"$1\" %s",
-                    is_keyword ? "keyword QREXEC_REQUESTED_TARGET_KEYWORD=\"$5\"" :
-                    (is_name ? "name QREXEC_REQUESTED_TARGET=\"$5\"" : ""),
-                    p == NULL ? "" : "\"QREXEC_SERVICE_ARGUMENT=$4\"",
-                    (p != NULL && p[1] != '\0') ? "\"$4\"" : "") < 0)
-            goto bad_asprintf;
-        argv[3] = "sh";
-        argv[4] = program;
-        argv[5] = full_name;
-        argv[6] = remote_domain;
-        argv[7] = p ? p + 1 : "";
-        argv[8] = requested_target;
-        argv[9] = NULL;
-        execve("/bin/sh", (char *const *)argv, buf);
-        /* /bin/sh should always exist */
-        _exit(QREXEC_EXIT_PROBLEM);
-bad_asprintf:
-        PERROR("asprintf");
-        _exit(QREXEC_EXIT_PROBLEM);
-    } else {
-        assert(strncmp(cmd, RPC_REQUEST_COMMAND, RPC_REQUEST_COMMAND_LEN) != 0);
+    for (char *const *env = envp; *env; ++env) {
+        // Set this 0 to 1 if adding new variable settings below,
+        // to ensure that MAX_ADDED_ENV_VARS is correct.
+        if (0 && should_strip_env_var(*env))
+            continue;
+        env_amount++;
     }
+#define EXTEND(...)                                         \
+    do {                                                    \
+        if (iterator >= env_amount)                         \
+            abort();                                        \
+        if (asprintf(&buf[iterator++], __VA_ARGS__) < 0)    \
+            goto bad_asprintf;                              \
+    } while (0)
+#define EXTEND_RAW(arg)                                     \
+    do {                                                    \
+        if (iterator >= env_amount)                         \
+            abort();                                        \
+        buf[iterator++] = (arg);                            \
+    } while (0)
+
+    char **buf = calloc(env_amount + 1, sizeof(char *));
+    if (buf == NULL) {
+        LOG(ERROR, "calloc(%zu, %zu) failed: %m", env_amount, sizeof(char *));
+        _exit(QREXEC_EXIT_PROBLEM);
+    }
+    size_t iterator = 0;
+    for (char *const *env = envp; *env; ++env) {
+        if (!should_strip_env_var(*env)) {
+            EXTEND_RAW(*env);
+        }
+    }
+
+    prog_copy = strdup(cmd);
+    if (!prog_copy) {
+        PERROR("strdup");
+        _exit(QREXEC_EXIT_PROBLEM);
+    }
+
+    argv[i++] = program;
+    tok=strtok_r(prog_copy, " ", &savetok);
+    while (tok != NULL) {
+        if (i >= sizeof(argv)/sizeof(argv[0])) {
+            LOG(ERROR, "Too many arguments to %s", RPC_REQUEST_COMMAND);
+            _exit(QREXEC_EXIT_PROBLEM);
+        }
+        argv[i++] = tok;
+        tok = strtok_r(NULL, " ", &savetok);
+    }
+
+    if (program[0] != '/') {
+        LOG(ERROR, "Program to execute not absolute path");
+        _exit(QREXEC_EXIT_PROBLEM);
+    }
+    if (i != 3 && i != 5) {
+        LOG(ERROR, "invalid number of arguments: %zu", i);
+        _exit(QREXEC_EXIT_PROBLEM);
+    }
+    const char *full_name = argv[1];
+    const char *remote_domain = argv[2];
+    const char *p = strchr(argv[1], '+');
+
+    // Change the 1 to a 0 to test the shell script generator.
+    if (!use_shell && 1) {
+        if (i == 5) {
+            EXTEND("QREXEC_REQUESTED_TARGET_TYPE=%s", argv[3]);
+            if (strcmp(argv[3], "name") == 0) {
+                EXTEND("QREXEC_REQUESTED_TARGET=%s", argv[4]);
+            } else if (strcmp(argv[3], "keyword") == 0) {
+                EXTEND("QREXEC_REQUESTED_TARGET_KEYWORD=%s", argv[4]);
+            } else {
+                // requested target type unknown or not given, ignore
+            }
+        } else {
+            EXTEND_RAW("QREXEC_REQUESTED_TARGET_TYPE=");
+        }
+        EXTEND("QREXEC_SERVICE_FULL_NAME=%s", full_name);
+        EXTEND("QREXEC_REMOTE_DOMAIN=%s", remote_domain);
+        argv[1] = NULL;
+        if (p != NULL) {
+            EXTEND("QREXEC_SERVICE_ARGUMENT=%s", p + 1);
+            if (p[1] != '\0') {
+                argv[1] = p + 1;
+                argv[2] = NULL;
+            }
+        }
+        assert(iterator <= env_amount);
+        buf[iterator] = NULL;
+        execve(program, (char *const *)argv, buf);
+        _exit(errno == ENOENT ? QREXEC_EXIT_SERVICE_NOT_FOUND : QREXEC_EXIT_PROBLEM);
+    }
+
+    // Generate a shell command and call it with the correct arguments.
+    // Note that is_name and is_keyword are mutually exclusive.
+    bool is_name = i == 5 && strcmp(argv[3], "name") == 0;
+    bool is_keyword = i == 5 && strcmp(argv[3], "keyword") == 0;
+    const char *requested_target = i == 5 ? argv[4] : NULL;
+    argv[0] = "/bin/sh";
+    argv[1] = "-lc";
+    // Build a shell script that emulates the old multiplexer.
+    // The shell script is only built from string literals,
+    // never data from the provided command.  Reviewers are
+    // invited to check that the produced script is always
+    // valid no matter what the inputs are.  To improve
+    // readability and maintainability, separating whitespace
+    // is included in the format string, so the arguments do
+    // not need to include it.  This means that the produced
+    // script might have unnecessary whitespace, but this is
+    // harmless.
+    if (asprintf((char **)(argv + 2),
+                // Unset the variables in case the user's shell init code did something weird,
+                // like mark them read-only or make them an array.
+                // Use set -e in case there is a problem.  Note that sh -el does not work
+                // because the startup files are not compatible with -e.
+                "set -e\n"
+                "unset QREXEC_SERVICE_FULL_NAME QREXEC_REMOTE_DOMAIN QREXEC_REQUESTED_TARGET_TYPE "
+                "QREXEC_SERVICE_ARGUMENT QREXEC_REQUESTED_TARGET QREXEC_REQUESTED_TARGET_KEYWORD\n"
+                "export \"QREXEC_SERVICE_FULL_NAME=$2\" \"QREXEC_REMOTE_DOMAIN=$3\" QREXEC_REQUESTED_TARGET_TYPE=%s %s\n"
+                // This could just be written as ${4:+"$4"}, which works just as well.
+                // I decided to make the C code more complicated so the shell has less work
+                // to do.
+                "exec \"$1\" %s",
+                is_keyword ? "keyword QREXEC_REQUESTED_TARGET_KEYWORD=\"$5\"" :
+                (is_name ? "name QREXEC_REQUESTED_TARGET=\"$5\"" : ""),
+                p == NULL ? "" : "\"QREXEC_SERVICE_ARGUMENT=$4\"",
+                (p != NULL && p[1] != '\0') ? "\"$4\"" : "") < 0)
+        goto bad_asprintf;
+    argv[3] = "sh";
+    argv[4] = program;
+    argv[5] = full_name;
+    argv[6] = remote_domain;
+    argv[7] = p ? p + 1 : "";
+    argv[8] = requested_target;
+    argv[9] = NULL;
+    execve("/bin/sh", (char *const *)argv, buf);
+    /* /bin/sh should always exist */
+    _exit(QREXEC_EXIT_PROBLEM);
+bad_asprintf:
+    PERROR("asprintf");
+    _exit(QREXEC_EXIT_PROBLEM);
 }
 
 void fix_fds(int fdin, int fdout, int fderr)
@@ -582,7 +572,9 @@ struct qrexec_parsed_command *parse_qubes_rpc_command(
         }
 
         /* Parse service descriptor ("qubes.Service+arg") */
-        start = cmd->command + RPC_REQUEST_COMMAND_LEN + 1;
+        cmd->command += RPC_REQUEST_COMMAND_LEN + 1;
+
+        start = cmd->command;
         end = strchr(start, ' ');
         if (!end) {
             LOG(ERROR, "No space found after service descriptor");
@@ -697,7 +689,7 @@ int execute_parsed_qubes_rpc_command(
             return 0;
         }
         return do_fork_exec(buf.data, cmd->username, cmd->command,
-                           pid, stdin_fd, stdout_fd, stderr_fd);
+                            pid, stdin_fd, stdout_fd, stderr_fd);
     } else {
         // Legacy qrexec behavior: spawn shell directly
         return do_fork_exec(NULL, cmd->username, cmd->command,
@@ -825,7 +817,7 @@ int find_qrexec_service(
 
         if (cmd->send_service_descriptor) {
             /* send part after "QUBESRPC ", including trailing NUL */
-            const char *desc = cmd->command + RPC_REQUEST_COMMAND_LEN + 1;
+            const char *desc = cmd->command;
             buffer_append(stdin_buffer, desc, strlen(desc) + 1);
         }
 
@@ -888,7 +880,7 @@ int find_qrexec_service(
 
         if (cmd->send_service_descriptor) {
             /* send part after "QUBESRPC ", including trailing NUL */
-            const char *desc = cmd->command + RPC_REQUEST_COMMAND_LEN + 1;
+            const char *desc = cmd->command;
             buffer_append(stdin_buffer, desc, strlen(desc) + 1);
         }
 

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -66,7 +66,8 @@ struct qrexec_parsed_command {
     /* Override to disable "wait for session" */
     bool nogui;
 
-    /* Command (the part after "user:") */
+    /* Command (the part after "user:").  If this is an RPC command
+     * then the "QUBESRPC " prefix is not included. */
     const char *command;
 
     /* The below parameters are NULL for legacy (non-"QUBESRPC") commands. */
@@ -144,23 +145,19 @@ __attribute__((visibility("default")))
 void register_exec_func(do_exec_t *func);
 
 /**
- * \param program Full path to program to execute or NULL.
- * \param cmd RPC command, including "QUBESRPC " prefix, if *program* is not NULL.
- *        Otherwise *program* must be NULL and *cmd* must not start with "QUBESRPC".
- * \param envp Environment passed to execve(), ignored if *program* is NULL.
+ * \param program Full path to program to execute.
+ * \param cmd RPC command, excluding "QUBESRPC " prefix.
+ * \param envp Environment passed to execve().
  * \param use_shell If true, use a login shell to spawn the program.
  *
- * If *program* is not NULL, execute it as an RPC service or call _exit() on failure.
+ * Execute *program* as an RPC service or call _exit() on failure.
  * *cmd* is used to set the argument (if any) and "QREXEC_*" environment variables.
  * Environment variables in *envp* that start with "QREXEC" are ignored, except for
- * "QREXEC_SERVICE_PATH" and "QREXEC_AGENT_PID", which are inherited.  If *program*
- * is not NULL and *cmd* does not start with "QUBESRPC ", or if *program* is NULL
- * and *cmd* starts with "QUBESRPC", fails an assertion.  If *program* is NULL and
- * *cmd* does not start with "QUBESRPC", returns without doing anything.
+ * "QREXEC_SERVICE_PATH" and "QREXEC_AGENT_PID", which are inherited.
  */
 __attribute__((visibility("default")))
-void exec_qubes_rpc_if_requested2(const char *program, const char *cmd, char *const envp[],
-                                  bool use_shell);
+_Noreturn void exec_qubes_rpc2(const char *program, const char *cmd, char *const envp[],
+                               bool use_shell);
 
 /* Execute `qubes.WaitForSession` service, do not return on success, return -1
  * (maybe setting errno) on failure. */

--- a/libqrexec/open_logger.c
+++ b/libqrexec/open_logger.c
@@ -1,0 +1,38 @@
+#include <unistd.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <libqrexec-utils.h>
+
+int open_logger(struct qrexec_parsed_command *command, int *pid)
+{
+    int pipes[2];
+    if (pipe2(pipes, O_CLOEXEC)) {
+        LOG(ERROR, "Cannot create status pipe");
+        return -1;
+    }
+    char *buf[] = {
+        "logger",
+        "-t",
+        NULL,
+        NULL,
+    };
+    if (asprintf(buf + 2, "%.*s-%s", (int)command->service_descriptor_len,
+                command->service_descriptor, command->source_domain) < 0) {
+        LOG(ERROR, "asprintf() failed");
+        return -1;
+    }
+    switch ((*pid = fork())) {
+    case -1:
+        LOG(ERROR, "Cannot fork logger process");
+        return -1;
+    case 0:
+        fix_fds(pipes[0], 1, 2);
+        execvp("logger", buf);
+        _exit(126);
+    default:
+        free(buf[2]);
+        close(pipes[0]);
+        return pipes[1];
+    }
+}

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -96,6 +96,7 @@ int qrexec_process_io(const struct process_io_request *req,
     int stdin_fd = req->stdin_fd;
     int stdout_fd = req->stdout_fd;
     int stderr_fd = req->stderr_fd;
+    int dup_fd = req->logger_fd;
     struct buffer *stdin_buf = req->stdin_buf;
 
     bool const is_service = req->is_service;
@@ -344,7 +345,7 @@ int qrexec_process_io(const struct process_io_request *req,
         if (prefix.len > 0 || (stdout_fd >= 0 && fds[FD_STDOUT].revents)) {
             switch (handle_input_v2(
                         vchan, stdout_fd, stdout_msg_type,
-                        &prefix, &remote_buffer)) {
+                        &prefix, &remote_buffer, -1)) {
                 case REMOTE_ERROR:
                     if (!is_service && remote_status == -1) {
                         /* Even if sending fails, still try to read remaining
@@ -365,7 +366,7 @@ int qrexec_process_io(const struct process_io_request *req,
         if (stderr_fd >= 0 && fds[FD_STDERR].revents) {
             switch (handle_input_v2(
                         vchan, stderr_fd, MSG_DATA_STDERR,
-                        &empty, &remote_buffer)) {
+                        &empty, &remote_buffer, dup_fd)) {
                 case REMOTE_ERROR:
                     handle_vchan_error("send(handle_input stderr)");
                     break;

--- a/libqrexec/qrexec.h
+++ b/libqrexec/qrexec.h
@@ -163,7 +163,6 @@ enum {
 #define QREXEC_AGENT_TRIGGER_PATH "/var/run/qubes/qrexec-agent"
 #define QREXEC_AGENT_FDPASS_PATH "/var/run/qubes/qrexec-agent-fdpass"
 #define MEMINFO_WRITER_PIDFILE "/var/run/meminfo-writer.pid"
-#define QUBES_RPC_MULTIPLEXER_PATH "/usr/lib/qubes/qubes-rpc-multiplexer"
 #define QREXEC_DAEMON_SOCKET_DIR "/var/run/qubes"
 #define QREXEC_POLICY_PROGRAM "/usr/bin/qrexec-policy-exec"
 #define QREXEC_SERVICE_PATH "/usr/local/etc/qubes-rpc:/etc/qubes-rpc"

--- a/libqrexec/remote.c
+++ b/libqrexec/remote.c
@@ -150,7 +150,8 @@ out:
 int handle_input_v2(
     libvchan_t *vchan, int fd, int msg_type,
     struct prefix_data *prefix_data,
-    const struct buffer *buffer)
+    const struct buffer *buffer,
+    int dup_fd)
 {
     const size_t max_len = (size_t)buffer->buflen;
     char *buf = buffer->data;
@@ -175,6 +176,8 @@ int handle_input_v2(
             prefix_data->len -= len;
         } else {
             len = read(fd, buf, len);
+            if (dup_fd != -1 && len > 0)
+                write_all(dup_fd, buf, (size_t)len);
             /* If the other side of the socket is a process that is already dead,
              * read from such socket could fail with ECONNRESET instead of
              * just 0. */

--- a/libqrexec/remote.h
+++ b/libqrexec/remote.h
@@ -73,9 +73,12 @@ int handle_remote_data_v2(
  * initialized, and will _not_ be anything meaningful on return.  The
  * buffer pointer and length will not be freed or reallocated, though.
  * In Rust terms: this is an &mut [MaybeUninit<u8>].
+ *
+ * If out_fd is not -1, all data written is duplicated to it.
  */
 int handle_input_v2(
     libvchan_t *vchan, int fd, int msg_type,
     struct prefix_data *prefix_data,
-    const struct buffer *buffer);
+    const struct buffer *buffer,
+    int out_fd);
 #pragma GCC visibility pop

--- a/qrexec/client.py
+++ b/qrexec/client.py
@@ -118,7 +118,7 @@ def make_command(dest, rpcname, arg):
             f"DEFAULT:QUBESRPC {rpcname} dom0",
         ]
     if VERSION == "vm":
-        return [QREXEC_CLIENT_VM, dest, rpcname]
+        return [QREXEC_CLIENT_VM, "--", dest, rpcname]
 
     assert VERSION is None
     raise NotImplementedError("qrexec not available")

--- a/qrexec/client.py
+++ b/qrexec/client.py
@@ -24,7 +24,6 @@ from .utils import prepare_subprocess_kwds
 
 QREXEC_CLIENT_DOM0 = "/usr/bin/qrexec-client"
 QREXEC_CLIENT_VM = "/usr/bin/qrexec-client-vm"
-RPC_MULTIPLEXER = "/usr/lib/qubes/qubes-rpc-multiplexer"
 
 VERSION = None
 
@@ -104,11 +103,6 @@ def make_command(dest, rpcname, arg):
     if arg is not None:
         assert " " not in arg
         rpcname = f"{rpcname}+{arg}"
-
-    if VERSION == "dom0" and dest == "dom0":
-        # Invoke qubes-rpc-multiplexer directly. This will work for non-socket
-        # services only.
-        return [RPC_MULTIPLEXER, rpcname, "dom0"]
 
     if VERSION == "dom0":
         return [

--- a/qrexec/client.py
+++ b/qrexec/client.py
@@ -100,7 +100,9 @@ async def call_async(dest, rpcname, arg=None, *, input=None):
 
 def make_command(dest, rpcname, arg):
     assert "+" not in rpcname
+    assert " " not in rpcname
     if arg is not None:
+        assert " " not in arg
         rpcname = f"{rpcname}+{arg}"
 
     if VERSION == "dom0" and dest == "dom0":

--- a/qrexec/client.py
+++ b/qrexec/client.py
@@ -18,6 +18,7 @@
 import pathlib
 import subprocess
 import asyncio
+from typing import Optional
 
 from .utils import prepare_subprocess_kwds
 
@@ -33,7 +34,7 @@ elif pathlib.Path(QREXEC_CLIENT_VM).is_file():
     VERSION = "vm"
 
 
-def call(dest, rpcname, arg=None, *, input=None):
+def call(dest: str, rpcname: str, arg: Optional[str] = None, *, input=None):
     """Invoke qrexec call
 
     The `input` parameter should be either :py:class:`str` or :py:class:`bytes`

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -1339,6 +1339,7 @@ class TestClientVm(unittest.TestCase):
             msg_type, msg_body = target.recv_message()
             self.assertEqual(msg_type, ty)
             l = len(msg_body)
+            self.assertGreater(l, 0)
             self.assertEqual(msg_body, expected_stdout[bytes_recvd:l])
             bytes_recvd += l
         self.assertEqual(bytes_recvd, expected)

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -434,6 +434,28 @@ printf 'something on stderr' >&2
         )
         self.check_dom0(dom0)
 
+    def test_exec_service_stderr_redirection(self):
+        """
+        USB forwarding expects to open /proc/PID/fd/2 for writing.
+        Check that this works.
+        """
+        util.make_executable_service(
+            self.tempdir,
+            "rpc",
+            "qubes.Service",
+            """\
+#!/bin/sh
+echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
+printf 'something on stderr' > /proc/self/fd/2
+""",
+        )
+        target, dom0 = self.execute_qubesrpc("qubes.Service+arg", "domX")
+        target.send_message(qrexec.MSG_DATA_STDIN, b"")
+        self.assertExpectedStdoutStderr(
+            target, b"arg: arg, remote domain: domX\n", b"something on stderr"
+        )
+        self.check_dom0(dom0)
+
     def test_exec_service_keyword(self):
         util.make_executable_service(
             self.tempdir,

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -58,25 +58,49 @@ class TestAgentBase(unittest.TestCase):
             ),
         )
 
-    def assertExpectedStdout(
-        self, target, expected_stdout: bytes, *, exit_code=0
-    ):
+    def assertExpectedStdoutStderr(
+        self,
+        target,
+        expected_stdout: bytes,
+        expected_stderr: bytes,
+        *,
+        exit_code: int = 0,
+    ) -> None:
         messages = util.sort_messages(target.recv_all_messages())
         self.assertListEqual(
-            messages[-3:],
+            messages[-2:],
             [
-                (qrexec.MSG_DATA_STDOUT, b""),
                 (qrexec.MSG_DATA_STDERR, b""),
                 (qrexec.MSG_DATA_EXIT_CODE, struct.pack("<L", exit_code)),
             ],
         )
-        stdout_entries = []
-        for msg_type, msg_body in messages[:-3]:
-            # messages before last are not empty, hence truthy
-            self.assertTrue(msg_body)
-            self.assertEqual(msg_type, qrexec.MSG_DATA_STDOUT)
-            stdout_entries.append(msg_body)
-        self.assertEqual(b"".join(stdout_entries), expected_stdout)
+        stdout_entries, stderr_entries = [], []
+        stdout_eof = False
+        for msg_type, msg_body in messages[:-2]:
+            match msg_type:
+                case qrexec.MSG_DATA_STDOUT:
+                    self.assertFalse(
+                        stdout_eof, "Got MSG_DATA_STDOUT after stdout EOF"
+                    )
+                    stdout_eof = not msg_body
+                    stdout_entries.append(msg_body)
+                case qrexec.MSG_DATA_STDERR:
+                    self.assertTrue(
+                        msg_body, "Got empty MSG_DATA_STDERR before stderr EOF"
+                    )
+                    stderr_entries.append(msg_body)
+                case invalid:
+                    self.fail(f"Invalid message type {invalid!r}")
+        self.assertTrue(stdout_eof, "No EOF on stdout")
+        self.assertEqual(expected_stdout, b"".join(stdout_entries))
+        self.assertEqual(expected_stderr, b"".join(stderr_entries))
+
+    def assertExpectedStdout(
+        self, target, expected_stdout: bytes, *, exit_code=0
+    ):
+        self.assertExpectedStdoutStderr(
+            target, expected_stdout, b"", exit_code=exit_code
+        )
 
     def make_executable_service(self, *args):
         util.make_executable_service(self.tempdir, *args)
@@ -187,7 +211,7 @@ class TestAgent(TestAgentBase):
         target.handshake()
         return target, dom0
 
-    def test_just_exec_socket(self):
+    def test_001_just_exec_socket(self):
         socket_path = os.path.join(self.tempdir, "rpc", "qubes.SocketService+")
         server = qrexec.socket_server(socket_path)
 
@@ -204,7 +228,7 @@ class TestAgent(TestAgentBase):
 
         self.check_dom0(dom0)
 
-    def test_just_exec(self):
+    def test_002_just_exec(self):
         fifo = os.path.join(self.tempdir, "new_file")
         os.mkfifo(fifo, mode=0o600)
         cmd = ("echo a >> " + shlex.quote(fifo)).encode("ascii", "strict")
@@ -219,7 +243,7 @@ class TestAgent(TestAgentBase):
             self.assertEqual(f.read(), b"a\n")
         self.check_dom0(dom0)
 
-    def test_just_exec_rpc(self):
+    def test_003_just_exec_rpc(self):
         fifo = os.path.join(self.tempdir, "new_file")
         os.mkfifo(fifo, mode=0o600)
         util.make_executable_service(
@@ -227,7 +251,8 @@ class TestAgent(TestAgentBase):
             "rpc",
             "qubes.Service",
             rf"""#!/bin/bash -eu
-printf %s\\n "$QREXEC_SERVICE_FULL_NAME" >> {shlex.quote(fifo)}
+printf %s "$QREXEC_SERVICE_FULL_NAME" >> {shlex.quote(fifo)}
+exit 1
 """,
         )
         cmd = b"QUBESRPC qubes.Service+ domX"
@@ -238,9 +263,8 @@ printf %s\\n "$QREXEC_SERVICE_FULL_NAME" >> {shlex.quote(fifo)}
                 (qrexec.MSG_DATA_EXIT_CODE, b"\0\0\0\0"),
             ],
         )
-
         with open(fifo, "rb") as f:
-            self.assertEqual(f.read(), b"qubes.Service+\n")
+            self.assertEqual(f.read(), b"qubes.Service+")
         self.check_dom0(dom0)
 
     def test_just_exec_rpc_not_found(self):
@@ -400,11 +424,14 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
             """\
 #!/bin/sh
 echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
+printf 'something on stderr' >&2
 """,
         )
         target, dom0 = self.execute_qubesrpc("qubes.Service+arg", "domX")
         target.send_message(qrexec.MSG_DATA_STDIN, b"")
-        self.assertExpectedStdout(target, b"arg: arg, remote domain: domX\n")
+        self.assertExpectedStdoutStderr(
+            target, b"arg: arg, remote domain: domX\n", b"something on stderr"
+        )
         self.check_dom0(dom0)
 
     def test_exec_service_keyword(self):
@@ -695,7 +722,7 @@ echo "specific service: $QREXEC_SERVICE_FULL_NAME"
             "rpc",
             "qubes.Service",
             """\
-#!/bin/sh
+#!/bin/sh --
 echo "general service"
 """,
         )

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -652,9 +652,6 @@ class TestClient(unittest.TestCase):
                 os.path.join(self.tempdir, "rpc"),
             ]
         )
-        env["QREXEC_MULTIPLEXER_PATH"] = os.path.join(
-            ROOT_PATH, "lib", "qubes-rpc-multiplexer"
-        )
         env["QUBES_RPC_CONFIG_PATH"] = os.path.join(self.tempdir, "rpc-config")
         cmd = [
             os.path.join(ROOT_PATH, "daemon", "qrexec-client"),
@@ -1109,12 +1106,12 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input, service path
 
     def test_run_dom0_service_3_args(self):
         self._test_run_dom0_service_failed(
-            exit_status=1, cmd="QUBESRPC qubes.Service+arg src_domain name"
+            cmd="QUBESRPC qubes.Service+arg src_domain name"
         )
 
     def test_run_dom0_service_5_args(self):
         self._test_run_dom0_service_failed(
-            exit_status=1, cmd="QUBESRPC qubes.Service+arg src_domain name a b"
+            cmd="QUBESRPC qubes.Service+arg src_domain name a b"
         )
 
     def test_run_dom0_service_not_found(self):

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -1000,36 +1000,73 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
     def test_exec_service_with_invalid_config_6(self):
         self.exec_service_with_invalid_config(None)
 
-    def _test_run_dom0_service_exec(self, nogui):
+    def assertExpectedStdout(
+        self, target, expected_stdout: bytes, exit_code: int = 0
+    ):
+        bytes_recvd, expected = 0, len(expected_stdout)
+        while bytes_recvd < expected:
+            msg_type, msg_body = target.recv_message()
+            self.assertEqual(msg_type, qrexec.MSG_DATA_STDOUT)
+            l = len(msg_body)
+            self.assertGreater(l, 0)
+            new_bytes_received = bytes_recvd + l
+            self.assertEqual(
+                msg_body, expected_stdout[bytes_recvd:new_bytes_received]
+            )
+            bytes_recvd = new_bytes_received
+        self.assertEqual(bytes_recvd, expected)
+        self.assertListEqual(
+            util.sort_messages(target.recv_all_messages()),
+            [
+                (qrexec.MSG_DATA_STDOUT, b""),
+                (qrexec.MSG_DATA_EXIT_CODE, struct.pack("<L", exit_code)),
+            ],
+        )
+
+    def _test_run_dom0_service_exec(self, nogui, requested_target="src_domain"):
         util.make_executable_service(
             self.tempdir,
             "rpc",
             "qubes.Service",
             """\
-#!/bin/sh
+#!/bin/sh -eu
 read input
-echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
+echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input, service path: $QREXEC_SERVICE_PATH"
+case $QREXEC_REQUESTED_TARGET_TYPE in
+(name) echo "requested target name: $QREXEC_REQUESTED_TARGET";;
+(keyword) echo "requested target keyword: $QREXEC_REQUESTED_TARGET_KEYWORD";;
+esac
 """,
         )
+        requested_target_type = "name"
+        if requested_target.startswith("@"):
+            requested_target = requested_target[1:]
+            requested_target_type = "keyword"
+        prefix = "nogui:" if nogui else ""
 
-        cmd = (
-            "nogui:" if nogui else ""
-        ) + "QUBESRPC qubes.Service+arg src_domain name src_domain"
+        cmd = f"{prefix}QUBESRPC qubes.Service+arg src_domain {requested_target_type} {requested_target}"
         source = self.connect_service_request(cmd)
 
         source.send_message(qrexec.MSG_DATA_STDIN, b"stdin data\n")
         source.send_message(qrexec.MSG_DATA_STDIN, b"")
-        self.assertEqual(
-            source.recv_all_messages(),
-            [
-                (
-                    qrexec.MSG_DATA_STDOUT,
-                    b"arg: arg, remote domain: src_domain, "
-                    b"input: stdin data\n",
-                ),
-                (qrexec.MSG_DATA_STDOUT, b""),
-                (qrexec.MSG_DATA_EXIT_CODE, b"\0\0\0\0"),
-            ],
+        service_path = (
+            ":".join(
+                [
+                    os.path.join(self.tempdir, "local-rpc"),
+                    os.path.join(self.tempdir, "rpc"),
+                ]
+            )
+        ).encode("ascii", "strict")
+        self.assertExpectedStdout(
+            source,
+            b"arg: arg, remote domain: src_domain, "
+            b"input: stdin data, service path: %s\n"
+            b"requested target %s: %s\n"
+            % (
+                service_path,
+                requested_target_type.encode("ascii", "strict"),
+                requested_target.encode("ascii", "strict"),
+            ),
         )
         self.client.wait()
         self.assertEqual(self.client.returncode, 0)
@@ -1037,13 +1074,27 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
     def test_run_dom0_service_exec(self):
         self._test_run_dom0_service_exec(False)
 
+    def test_run_dom0_service_exec_keyword(self):
+        self._test_run_dom0_service_exec(False, requested_target="@adminvm")
+
     def test_run_dom0_service_exec_nogui(self):
         self._test_run_dom0_service_exec(True)
 
     def _test_run_dom0_service_failed(
-        self, exit_status=qrexec.QREXEC_EXIT_PROBLEM
+        self, exit_status=qrexec.QREXEC_EXIT_PROBLEM, cmd=""
     ):
-        cmd = "QUBESRPC qubes.Service+arg src_domain name src_domain"
+        if cmd:
+            # presumably the command is invalid, so the service won't get called"
+            util.make_executable_service(
+                self.tempdir,
+                "rpc",
+                "qubes.Service",
+                """#!/bin/sh
+echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input, service path: $QREXEC_SERVICE_PATH"
+""",
+            )
+        else:
+            cmd = "QUBESRPC qubes.Service+arg src_domain name src_domain"
         source = self.connect_service_request(cmd)
 
         self.assertEqual(
@@ -1055,6 +1106,16 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
         )
         self.client.wait()
         self.assertEqual(self.client.returncode, exit_status)
+
+    def test_run_dom0_service_3_args(self):
+        self._test_run_dom0_service_failed(
+            exit_status=1, cmd="QUBESRPC qubes.Service+arg src_domain name"
+        )
+
+    def test_run_dom0_service_5_args(self):
+        self._test_run_dom0_service_failed(
+            exit_status=1, cmd="QUBESRPC qubes.Service+arg src_domain name a b"
+        )
 
     def test_run_dom0_service_not_found(self):
         # qubes.Service does not exist

--- a/selinux/qubes-core-qrexec.fc
+++ b/selinux/qubes-core-qrexec.fc
@@ -1,1 +1,3 @@
-/usr/lib/qubes/qrexec-agent -- gen_context(system_u:object_r:qubes_qrexec_agent_exec_t,s0)
+/usr/lib/qubes/qrexec-agent	--	gen_context(system_u:object_r:qubes_qrexec_agent_exec_t,s0)
+/etc/qubes-rpc(/.*)?	gen_context(system_u:object_r:bin_t,s0)
+/usr/local/etc/qubes-rpc(/.*)?	--	gen_context(system_u:object_r:bin_t,s0)


### PR DESCRIPTION
Instead, directly execute the command from C.

The command’s environment inherits all environment variables from the
calling process _except_ for those that start with `QREXEC`.  Environment
variables that start with `QREXEC` are _not_ inherited, except for
`QREXEC_SERVICE_PATH` and `QREXEC_AGENT_PID`, but the following are set
explicitly:

- `QREXEC_SERVICE_FULL_NAME`
- `QREXEC_REMOTE_DOMAIN`
- `QREXEC_SERVICE_ARGUMENT` if the service argument is present and non-empty.
- `QREXEC_AGENT_PID` is set for calls to a VM that do not use `MSG_JUST_EXEC`.
  Its handling in other cases is inconsistent, so such services should avoid it.

When the request is made to dom0, the following are also set:

- `QREXEC_REQUESTED_TARGET_TYPE` is set to `name` if the requested target does not start with
- `QREXEC_REQUESTED_TARGET` for services in dom0 if the target does not start with `@`.
- `QREXEC_REQUESTED_TARGET_KEYWORD` for services in dom0 if the target does start with `@`.
  The leading `@` is removed, but subsequent `@` are left unchanged.

This is a backwards-incompatible change to libqrexec.  Therefore, it cannot be backported to R4.2.

Fixes: QubesOS/qubes-issues#9062