### PR TITLE
Support socket services with `MSG_JUST_EXEC`

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -136,6 +136,16 @@ static int handle_just_exec(struct qrexec_parsed_command *cmd)
 
     if (cmd == NULL)
         return 127;
+
+    if (cmd->service_descriptor) {
+        int socket_fd;
+        struct buffer stdin_buffer;
+        buffer_init(&stdin_buffer);
+        if (!find_qrexec_service(cmd, &socket_fd, &stdin_buffer))
+            return 127;
+        if (socket_fd != -1)
+            return write_all(socket_fd, stdin_buffer.data, stdin_buffer.buflen) ? 0 : 127;
+    }
     switch (pid = fork()) {
         case -1:
             PERROR("fork");

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -127,7 +127,7 @@ int write_stdin(int fd, const char *data, int len, struct buffer *buffer);
 
 /**
  * @brief Execute an already-parsed Qubes RPC command.
- * @param cmdline Null-terminated command to execute.
+ * @param cmd Already-parsed command to execute.
  * @param pid On return, holds the PID of the child process.
  * @param stdin_fd On return, holds a file descriptor connected to the child's
  * stdin.
@@ -143,6 +143,24 @@ int write_stdin(int fd, const char *data, int len, struct buffer *buffer);
 int execute_parsed_qubes_rpc_command(
         const struct qrexec_parsed_command *cmd, int *pid, int *stdin_fd,
         int *stdout_fd, int *stderr_fd, struct buffer *stdin_buffer);
+
+/**
+ * @brief Find the implementation of a Qubes RPC command. If it is a socket,
+ *        connect to it.
+ * @param[in] cmdline Null-terminated command to execute.
+ * @param[out] socket_fd On return, holds a file descriptor connected to the socket,
+ * or -1 for executable services.
+ * @param stdin_buffer This buffer will need to be prepended to the child process’s
+ * stdin.
+ * @return true if the implementation is found (and, for sockets, connected to)
+ * successfully, false on failure.
+ */
+bool find_qrexec_service(
+        const struct qrexec_parsed_command *cmd,
+        int *socket_fd, struct buffer *stdin_buffer);
+
+/** Suggested buffer size for the path buffer of find_qrexec_service. */
+#define QUBES_SOCKADDR_UN_MAX_PATH_LEN 1024
 
 /**
  * @brief Execute a Qubes RPC command.


### PR DESCRIPTION
This separates _finding_ a qrexec service (and, if necessary, connecting to a socket) from actually _executing_ the service and processing I/O. This allows qrexec-agent to handle `MSG_JUST_EXEC` correctly, because it can connect to a socket-based service without having to be prepared for an executable service to be run immediately.  Instead, qrexec-agent spawns an executable service using its own spawning routines that do support `MSG_JUST_EXEC`.

This also adds tests for RPC services (both executable and socket) with `MSG_JUST_EXEC`.  Previously, these were not tested, despite being essential to a running system.  For instance, the Qubes app menu uses `MSG_JUST_EXEC` to invoke the qubes.StartApp service every time it launches an application in a non-disposable VM from dom0.