### PR TITLE
Avoid using alarm(2) for timeouts

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -150,69 +150,6 @@ static int handle_just_exec(struct qrexec_parsed_command *cmd)
     return 0;
 }
 
-static const long BILLION_NANOSECONDS = 1000000000L;
-
-static int wait_for_vchan_connection_with_timeout(
-        libvchan_t *conn, int wait_fd, bool is_server, time_t timeout) {
-    struct timespec end_tp, now_tp, timeout_tp;
-
-    if (timeout && clock_gettime(CLOCK_MONOTONIC, &end_tp)) {
-        PERROR("clock_gettime");
-        return -1;
-    }
-    assert(end_tp.tv_nsec >= 0 && end_tp.tv_nsec < BILLION_NANOSECONDS);
-    end_tp.tv_sec += timeout;
-    while (true) {
-        bool did_timeout = true;
-        struct pollfd fds = { .fd = wait_fd, .events = POLLIN | POLLHUP, .revents = 0 };
-
-        /* calculate how much time left until connection timeout expire */
-        if (clock_gettime(CLOCK_MONOTONIC, &now_tp)) {
-            PERROR("clock_gettime");
-            return -1;
-        }
-        assert(now_tp.tv_nsec >= 0 && now_tp.tv_nsec < BILLION_NANOSECONDS);
-        if (now_tp.tv_sec <= end_tp.tv_sec) {
-            timeout_tp.tv_sec = end_tp.tv_sec - now_tp.tv_sec;
-            timeout_tp.tv_nsec = end_tp.tv_nsec - now_tp.tv_nsec;
-            if (timeout_tp.tv_nsec < 0) {
-                timeout_tp.tv_nsec += BILLION_NANOSECONDS;
-                timeout_tp.tv_sec--;
-            }
-            did_timeout = timeout_tp.tv_sec < 0;
-        }
-        switch (did_timeout ? 0 : ppoll(&fds, 1, &timeout_tp, NULL)) {
-            case -1:
-                if (errno == EINTR)
-                    break;
-                LOG(ERROR, "vchan connection error");
-                return -1;
-            case 0:
-                LOG(ERROR, "vchan connection timeout");
-                return -1;
-            case 1:
-                break;
-            default:
-                abort();
-        }
-        if (fds.revents & POLLIN) {
-            if (is_server) {
-                libvchan_wait(conn);
-                return 0;
-            } else {
-                int connect_ret = libvchan_client_init_async_finish(conn, true);
-
-                if (connect_ret < 0) {
-                    LOG(ERROR, "vchan connection error");
-                    return -1;
-                } else if (connect_ret == 0) {
-                    return 0;
-                }
-            }
-        }
-    }
-}
-
 
 /* Behaviour depends on type parameter:
  *  MSG_JUST_EXEC - connect to vchan server, fork+exec process given by cmdline
@@ -253,7 +190,8 @@ static int handle_new_process_common(
         LOG(ERROR, "Data vchan connection failed");
         exit(1);
     }
-    if (wait_for_vchan_connection_with_timeout(data_vchan, wait_fd, false, connection_timeout) < 0) {
+    if (qubes_wait_for_vchan_connection_with_timeout(
+                data_vchan, wait_fd, false, connection_timeout) < 0) {
         LOG(ERROR, "Data vchan connection failed");
         exit(1);
     }
@@ -381,7 +319,7 @@ int handle_data_client(
         LOG(ERROR, "Data vchan connection failed");
         exit(1);
     }
-    if (wait_for_vchan_connection_with_timeout(
+    if (qubes_wait_for_vchan_connection_with_timeout(
             data_vchan, libvchan_fd_for_select(data_vchan), true, connection_timeout) < 0) {
         LOG(ERROR, "Data vchan connection failed");
         exit(1);

--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -74,8 +74,14 @@ static void sigusr1_handler(int __attribute__((__unused__))x)
 void prepare_child_env(void) {
     char pid_s[10];
 
-    signal(SIGCHLD, sigchld_handler);
-    signal(SIGUSR1, sigusr1_handler);
+    struct sigaction action = {
+        .sa_handler = sigchld_handler,
+        .sa_flags = 0,
+    };
+    sigemptyset(&action.sa_mask);
+    if (sigaction(SIGCHLD, &action, NULL)) abort();
+    action.sa_handler = sigusr1_handler;
+    if (sigaction(SIGUSR1, &action, NULL)) abort();
     int res = snprintf(pid_s, sizeof(pid_s), "%d", getpid());
     if (res < 0) abort();
     if (res >= (int)sizeof(pid_s)) abort();

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -928,8 +928,14 @@ int main(int argc, char **argv)
     }
 
     init();
-    signal(SIGCHLD, sigchld_handler);
-    signal(SIGTERM, sigterm_handler);
+    struct sigaction action = {
+        .sa_handler = sigchld_handler,
+        .sa_flags = SA_RESTART,
+    };
+    sigemptyset(&action.sa_mask);
+    sigaction(SIGCHLD, &action, NULL);
+    action.sa_handler = sigterm_handler;
+    sigaction(SIGTERM, &action, NULL);
     signal(SIGPIPE, SIG_IGN);
 
     sigemptyset(&selectmask);

--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -124,10 +124,6 @@ int main(int argc, char **argv) {
     }
 
     s = get_server_socket(socket_path);
-    if (fcntl(s, F_SETFD, O_CLOEXEC) < 0) {
-        PERROR("fcntl");
-        exit(1);
-    }
     /* fork into background */
     switch (fork()) {
         case -1:

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -338,7 +338,6 @@ static void init(int xid)
         }
     }
 
-    close(0);
 
     if (chdir(socket_dir) < 0) {
         PERROR("chdir %s failed", socket_dir);
@@ -1571,6 +1570,18 @@ int main(int argc, char **argv)
 {
     int i, opt;
     sigset_t selectmask;
+
+    {
+        int null_fd = open("/dev/null", O_RDONLY|O_NOCTTY);
+        if (null_fd < 0)
+            err(1, "open(%s)", "/dev/null");
+        if (null_fd > 0) {
+            if (dup2(null_fd, 0) != 0)
+                err(1, "dup2(%d, 0)", null_fd);
+            if (null_fd > 2 && close(null_fd) != 0)
+                err(1, "close(%d)", null_fd);
+        }
+    }
 
     setup_logging("qrexec-daemon");
 

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -413,6 +413,8 @@ static void init(int xid)
         .sa_handler = signal_handler,
         .sa_flags = 0,
     };
+    sigemptyset(&sigchld_action.sa_mask);
+    sigemptyset(&sigterm_action.sa_mask);
     if (signal(SIGPIPE, SIG_IGN) == SIG_ERR)
         err(1, "signal");
     if (sigaction(SIGCHLD, &sigchld_action, NULL))

--- a/fuzz/Makefile
+++ b/fuzz/Makefile
@@ -16,7 +16,7 @@ CXXFLAGS += -O1 -fno-omit-frame-pointer -gline-tables-only \
 		-fsanitize-address-use-after-scope -fsanitize=fuzzer
 endif
 
-_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o toml.o process_io.o
+_LIBQREXEC_OBJS = remote.o write-stdin.o ioall.o txrx-vchan.o buffer.o replace.o exec.o log.o unix-server.o toml.o process_io.o vchan_timeout.o
 LIBQREXEC_OBJS = $(patsubst %.o,libqrexec-%.o,$(_LIBQREXEC_OBJS))
 
 FUZZERS = qubesrpc_parse_fuzzer qrexec_remote_fuzzer qrexec_daemon_fuzzer

--- a/fuzz/fuzz.c
+++ b/fuzz/fuzz.c
@@ -140,7 +140,18 @@ ssize_t fuzz_write(int fd, const void *buf, size_t count) {
     return count;
 }
 
+typedef int EVTCHN;
 fuzz_file_t *fuzz_libvchan_client_init(int domain, int port) {
+    /* not implemented yet */
+    abort();
+}
+
+fuzz_file_t *fuzz_libvchan_client_init_async(int domain, int port, EVTCHN *watch_fd) {
+    /* not implemented yet */
+    abort();
+}
+
+int fuzz_libvchan_client_init_async_finish(fuzz_file_t *ctrl, bool blocking) {
     /* not implemented yet */
     abort();
 }

--- a/fuzz/fuzz.h
+++ b/fuzz/fuzz.h
@@ -31,6 +31,8 @@ int fuzz_libvchan_is_open(fuzz_file_t *file);
 int fuzz_libvchan_data_ready(fuzz_file_t *file);
 int fuzz_libvchan_buffer_space(fuzz_file_t *file);
 fuzz_file_t *fuzz_libvchan_client_init(int domain, int port);
+fuzz_file_t *fuzz_libvchan_client_init_async(int domain, int port, int *fd);
+int fuzz_libvchan_client_init_async_finish(fuzz_file_t *file, bool blocking);
 
 ssize_t fuzz_read(int fd, void *buf, size_t count);
 ssize_t fuzz_write(int fd, const void *buf, size_t count);

--- a/fuzz/mock-fuzz.h
+++ b/fuzz/mock-fuzz.h
@@ -16,6 +16,8 @@
 #define libvchan_data_ready fuzz_libvchan_data_ready
 #define libvchan_buffer_space fuzz_libvchan_buffer_space
 #define libvchan_client_init fuzz_libvchan_client_init
+#define libvchan_client_init_async fuzz_libvchan_client_init_async
+#define libvchan_client_init_async_finish fuzz_libvchan_client_init_async_finish
 
 #define read fuzz_read
 #define write fuzz_write

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -21,7 +21,7 @@ endif
 
 
 all: libqrexec-utils.so
-libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o toml.o
+libqrexec-utils.so.$(SO_VER): unix-server.o ioall.o buffer.o exec.o txrx-vchan.o write-stdin.o replace.o remote.o process_io.o log.o toml.o vchan_timeout.o
 	$(CC) $(LDFLAGS) -Wl,-soname,$@ -o $@ $^ $(VCHANLIBS)
 
 libqrexec-utils.so: libqrexec-utils.so.$(SO_VER)

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -32,6 +32,7 @@
 #include <poll.h>
 #include <sys/socket.h>
 
+#include <libvchan.h>
 #include <qrexec.h>
 
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
@@ -347,4 +348,15 @@ void *qubes_read_all_to_malloc(int fd, size_t initial_buffer_size, size_t max_by
  */
 bool qubes_sendmsg_all(struct msghdr *msg, int sock);
 
+/**
+ * Wait for a vchan connection with a timeout.
+ *
+ * @param conn the vchan
+ * @param wait_fd The FD set by libvchan_client_init_async() for clients,
+ *                or the FD returned by libvchan_fd_for_select() for servers.
+ * @param is_server Is this a server or a client vchan?
+ * @param timeout The timeout to use.
+ */
+int qubes_wait_for_vchan_connection_with_timeout(
+        libvchan_t *conn, int wait_fd, bool is_server, time_t timeout);
 #endif /* LIBQREXEC_UTILS_H */

--- a/libqrexec/qrexec.h
+++ b/libqrexec/qrexec.h
@@ -173,4 +173,11 @@ enum {
 // support only very small configuration files,
 #define MAX_CONFIG_SIZE 4096
 
+// Exit codes
+
+// Service call refused
+#define QREXEC_EXIT_REQUEST_REFUSED 126
+// Problem with qrexec itself
+#define QREXEC_EXIT_PROBLEM 125
+
 #endif /* QREXEC_H */

--- a/libqrexec/unix-server.c
+++ b/libqrexec/unix-server.c
@@ -36,7 +36,7 @@ int get_server_socket(const char *socket_address)
 
     unlink(socket_address);
 
-    s = socket(AF_UNIX, SOCK_STREAM, 0);
+    s = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
     if (s < 0) {
         PERROR("socket");
         exit(1);

--- a/libqrexec/vchan_timeout.c
+++ b/libqrexec/vchan_timeout.c
@@ -1,0 +1,67 @@
+#include <libqrexec-utils.h>
+#include <time.h>
+#include <assert.h>
+#include <stdlib.h>
+
+static const long BILLION_NANOSECONDS = 1000000000L;
+
+int qubes_wait_for_vchan_connection_with_timeout(
+        libvchan_t *conn, int wait_fd, bool is_server, time_t timeout) {
+    struct timespec end_tp, now_tp, timeout_tp;
+
+    if (clock_gettime(CLOCK_MONOTONIC, &end_tp)) {
+        PERROR("clock_gettime");
+        return -1;
+    }
+    assert(end_tp.tv_nsec >= 0 && end_tp.tv_nsec < BILLION_NANOSECONDS);
+    end_tp.tv_sec += timeout;
+    for (;;) {
+        bool did_timeout = true;
+        struct pollfd fds = { .fd = wait_fd, .events = POLLIN | POLLHUP, .revents = 0 };
+
+        /* calculate how much time left until connection timeout expire */
+        if (clock_gettime(CLOCK_MONOTONIC, &now_tp)) {
+            PERROR("clock_gettime");
+            return -1;
+        }
+        assert(now_tp.tv_nsec >= 0 && now_tp.tv_nsec < BILLION_NANOSECONDS);
+        if (now_tp.tv_sec <= end_tp.tv_sec) {
+            timeout_tp.tv_sec = end_tp.tv_sec - now_tp.tv_sec;
+            timeout_tp.tv_nsec = end_tp.tv_nsec - now_tp.tv_nsec;
+            if (timeout_tp.tv_nsec < 0) {
+                timeout_tp.tv_nsec += BILLION_NANOSECONDS;
+                timeout_tp.tv_sec--;
+            }
+            did_timeout = timeout_tp.tv_sec < 0;
+        }
+        switch (did_timeout ? 0 : ppoll(&fds, 1, &timeout_tp, NULL)) {
+            case -1:
+                if (errno == EINTR)
+                    break;
+                LOG(ERROR, "vchan connection error");
+                return -1;
+            case 0:
+                LOG(ERROR, "vchan connection timeout");
+                return -1;
+            case 1:
+                break;
+            default:
+                abort();
+        }
+        if (fds.revents & POLLIN) {
+            if (is_server) {
+                libvchan_wait(conn);
+                return 0;
+            } else {
+                int connect_ret = libvchan_client_init_async_finish(conn, true);
+
+                if (connect_ret < 0) {
+                    LOG(ERROR, "vchan connection error");
+                    return -1;
+                } else if (connect_ret == 0) {
+                    return 0;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
libvchan has much better ways of dealing with timeouts now, so use them instead of calling an async signal unsafe function from a signal handler.  Both qrexec-agent-data.c and qrexec-daemon-common.c reimplemented timeouts, so write common code in libqrexec for both to use.

Based on #136 which is already approved.