### PR TITLE
Avoid writing to an uninitialized file descriptor

### DIFF
--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -360,8 +360,10 @@ static void init(int xid, bool opt_direct)
             exit(1);
         }
 
-        dup2(logfd, 1);
-        dup2(logfd, 2);
+        if (dup2(logfd, 1) != 1 || dup2(logfd, 2) != 2)
+            err(1, "dup2()");
+        if (logfd > 2)
+            close(logfd);
 
         if (setsid() < 0) {
             PERROR("setsid()");


### PR DESCRIPTION
Found by clang-tidy.  No tests, but the fix is trivial.

Fixes: 3d658cc82739 ("Use a pipe instead of signals to notify readiness")