### PR TITLE
Do not make a file description blocking while it is still in use

### DIFF
--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -155,7 +155,8 @@ bool send_service_connect(int s, const char *conn_ident,
 
 #define QREXEC_DATA_MIN_VERSION QREXEC_PROTOCOL_V2
 
-static int local_stdin_fd = 1, local_stdout_fd = 0;
+static int local_stdout_fd = 0;
+int local_stdin_fd = 1;
 static pid_t local_pid = 0;
 
 static volatile sig_atomic_t sigchld = 0;

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -38,3 +38,5 @@ __attribute__((warn_unused_result))
 int handle_agent_handshake(libvchan_t *vchan, bool remote_send_first);
 __attribute__((warn_unused_result))
 int prepare_local_fds(struct qrexec_parsed_command *command, struct buffer *stdin_buffer);
+/* FD for stdout of remote process */
+extern int local_stdin_fd;

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -81,6 +81,11 @@ void exec_qubes_rpc_if_requested(const char *prog, char *const envp[]) {
 
 void fix_fds(int fdin, int fdout, int fderr)
 {
+    if (fdin < 0 || fdout < 1 || fderr < 2) {
+        LOG(ERROR, "fix_fds: bad FD numbers: fdin %d, fdout %d, fderr %d",
+            fdin, fdout, fderr);
+        _exit(125);
+    }
     int i;
     for (i = 3; i < 256; i++)
         if (i != fdin && i != fdout && i != fderr)

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -276,6 +276,9 @@ struct process_io_request {
     libvchan_t *vchan;
     struct buffer *stdin_buf;
 
+    /* Note that stdin_fd, stdout_fd, and stderr_fd are named assuming a
+     * *local* process.  For a *remote* process, stdin_fd is the standard
+     * *output*, stdout_fd is the standard *input*, and stderr_fd must be -1. */
     // stderr_fd can be -1
     int stdin_fd, stdout_fd, stderr_fd;
     // 0 if no child process
@@ -284,12 +287,14 @@ struct process_io_request {
     /*
       is_service true (this is a service):
         - send local data as MSG_DATA_STDOUT
+        - send local stderr as MSG_DATA_STDERR, unless in dom0
         - send exit code
         - wait just for local end
         - return local exit code
 
       is_service false (this is a client):
         - send local data as MSG_DATA_STDIN
+        - stderr_fd is always -1
         - don't send exit code
         - wait for local and remote end
         - return remote exit code

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -19,6 +19,7 @@
  *
  */
 
+#include <assert.h>
 #include <signal.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
@@ -110,8 +111,10 @@ int process_io(const struct process_io_request *req) {
     set_nonblock(stdin_fd);
     if (stdout_fd != stdin_fd)
         set_nonblock(stdout_fd);
-    if (stderr_fd >= 0)
+    if (stderr_fd >= 0) {
+        assert(is_service); // if this is a client, stderr_fd is *always* -1
         set_nonblock(stderr_fd);
+    }
 
     /* Convenience macros that eliminate a ton of error-prone boilerplate */
 #define close_stdin() do {                      \

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -40,45 +40,24 @@ static _Noreturn void handle_vchan_error(const char *op)
 /*
  * Closing the file descriptors:
  *
- * - Use shutdown(), except if this is a FD inherited from parent (detected by
- *   FD number)
- * - Restore blocking status, unless this is a duplicated stdio socket for
- *   stdout/stderr (in which case we can't restore it just for one FD, but we
- *   don't care, because we created it)
+ * - If this is a single socket used for both stdin and stdout, call shutdown()
+ *   to indicate that no more data will be sent or received.
+ * - Otherwise, restore the blocking status of the FD.
  */
-
-static void close_stdin(int fd, bool restore_block) {
+static void close_stdio(int fd, int other_fd, int direction) {
     if (fd == -1)
         return;
-
-    if (restore_block)
-        set_block(fd);
-
-    if (fd == 1) {
-        close(fd);
-    } else if (shutdown(fd, SHUT_WR) == -1) {
-        if (errno == ENOTSOCK)
-            close(fd);
-        else
-            PERROR("shutdown close_stdin");
-    }
-}
-
-static void close_stdout(int fd, bool restore_block) {
-    if (fd == -1)
+    if (fd == other_fd) {
+        /* Do not close the FD, as it is still in use. */
+        /* ENOTCONN can happen with TCP and is harmless */
+        if (shutdown(fd, direction) == -1 && errno != ENOTSOCK && errno != ENOTCONN)
+            PERROR("shutdown");
         return;
-
-    if (restore_block)
-        set_block(fd);
-
-    if (fd == 0) {
-        close(fd);
-    } else if (shutdown(fd, SHUT_RD) == -1) {
-        if (errno == ENOTSOCK)
-            close(fd);
-        else if (errno != ENOTCONN) /* can happen with TCP, harmless */
-            PERROR("shutdown close_stdout");
     }
+
+    if (fd < 3)
+        set_block(fd);
+    close(fd);
 }
 
 static void close_stderr(int fd) {
@@ -116,8 +95,6 @@ int process_io(const struct process_io_request *req) {
     pid_t local_status = -1;
     pid_t remote_status = -1;
     int stdout_msg_type = is_service ? MSG_DATA_STDOUT : MSG_DATA_STDIN;
-    bool use_stdio_socket = false;
-
     int ret;
     struct pollfd fds[FD_NUM];
     sigset_t pollmask;
@@ -133,10 +110,19 @@ int process_io(const struct process_io_request *req) {
     set_nonblock(stdin_fd);
     if (stdout_fd != stdin_fd)
         set_nonblock(stdout_fd);
-    else if ((stdout_fd = fcntl(stdin_fd, F_DUPFD_CLOEXEC, 3)) < 0)
-        abort(); // not worth handling running out of file descriptors
     if (stderr_fd >= 0)
         set_nonblock(stderr_fd);
+
+    /* Convenience macros that eliminate a ton of error-prone boilerplate */
+#define close_stdin() do {                      \
+    close_stdio(stdin_fd, stdout_fd, SHUT_WR);  \
+    stdin_fd = -1;                              \
+} while (0)
+#define close_stdout() do {                     \
+    close_stdio(stdout_fd, stdin_fd, SHUT_RD);  \
+    stdout_fd = -1;                             \
+} while (0)
+#pragma GCC poison close_stdio
 
     while(1) {
         /* React to SIGCHLD */
@@ -147,10 +133,7 @@ int process_io(const struct process_io_request *req) {
                     local_status = 128 + WTERMSIG(status);
                 else
                     local_status = WEXITSTATUS(status);
-                if (stdin_fd >= 0) {
-                    close_stdin(stdin_fd, !use_stdio_socket);
-                    stdin_fd = -1;
-                }
+                close_stdin();
             }
             *sigchld = 0;
         }
@@ -193,24 +176,9 @@ int process_io(const struct process_io_request *req) {
         }
 
         /* child signaled desire to use single socket for both stdin and stdout */
-        if (sigusr1 && *sigusr1) {
-            if (stdout_fd != -1) {
-                do
-                    errno = 0;
-                while (dup3(stdin_fd, stdout_fd, O_CLOEXEC) &&
-                       (errno == EINTR || errno == EBUSY));
-                // other errors are fatal
-                if (errno) {
-                    PERROR("dup3");
-                    abort();
-                }
-            } else {
-                stdout_fd = fcntl(stdin_fd, F_DUPFD_CLOEXEC, 3);
-                // all errors are fatal
-                if (stdout_fd < 3)
-                    abort();
-            }
-            use_stdio_socket = true;
+        if (sigusr1 && *sigusr1 && stdin_fd != stdout_fd) {
+            close_stdout();
+            stdout_fd = stdin_fd;
             *sigusr1 = 0;
         }
 
@@ -263,10 +231,8 @@ int process_io(const struct process_io_request *req) {
             if (libvchan_wait(vchan) < 0)
                 handle_vchan_error("wait");
 
-        if (stdin_fd >= 0 && fds[FD_STDIN].revents & (POLLHUP | POLLERR)) {
-            close_stdin(stdin_fd, !use_stdio_socket);
-            stdin_fd = -1;
-        }
+        if (fds[FD_STDIN].revents & (POLLHUP | POLLERR))
+            close_stdin();
 
         /* handle_remote_data will check if any data is available */
         switch (handle_remote_data(
@@ -281,16 +247,14 @@ int process_io(const struct process_io_request *req) {
                 handle_vchan_error("read");
                 break;
             case REMOTE_EOF:
-                close_stdin(stdin_fd, !use_stdio_socket);
-                stdin_fd = -1;
+                close_stdin();
                 break;
             case REMOTE_EXITED:
                 /* Remote process exited, we don't need any more data from
                  * local FDs. However, don't exit yet, because there might
                  * still be some data in stdin_buf waiting to be flushed.
                  */
-                close_stdout(stdout_fd, !use_stdio_socket);
-                stdout_fd = -1;
+                close_stdout();
                 close_stderr(stderr_fd);
                 stderr_fd = -1;
                 break;
@@ -303,8 +267,7 @@ int process_io(const struct process_io_request *req) {
                     handle_vchan_error("send(handle_input stdout)");
                     break;
                 case REMOTE_EOF:
-                    close_stdout(stdout_fd, !use_stdio_socket);
-                    stdout_fd = -1;
+                    close_stdout();
                     break;
             }
         }
@@ -324,8 +287,8 @@ int process_io(const struct process_io_request *req) {
     }
     /* make sure that all the pipes/sockets are closed, so the child process
      * (if any) will know that the connection is terminated */
-    close_stdin(stdin_fd, true);
-    close_stdout(stdout_fd, true);
+    close_stdin();
+    close_stdout();
     close_stderr(stderr_fd);
 
     /* wait for local process, in case we exited early */

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -1173,11 +1173,24 @@ class TestClientVm(unittest.TestCase):
     target_domain = 43
     target_port = 1024
 
+    def assertStdoutMessages(self, target, expected_stdout: bytes, ty=qrexec.MSG_DATA_STDOUT):
+        bytes_recvd, expected = 0, len(expected_stdout)
+        while bytes_recvd < expected:
+            msg_type, msg_body = target.recv_message()
+            self.assertEqual(msg_type, ty)
+            l = len(msg_body)
+            self.assertEqual(msg_body, expected_stdout[bytes_recvd:l])
+            bytes_recvd += l
+        self.assertEqual(bytes_recvd, expected)
+
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, self.tempdir)
 
-    def start_client(self, args):
+    def start_client(self, args, stdio=subprocess.PIPE):
+        if stdio is not subprocess.PIPE:
+            self.assertIsInstance(stdio, socket.socket)
+            args.insert(0, "--use-stdin-socket")
         env = os.environ.copy()
         env["LD_LIBRARY_PATH"] = os.path.join(ROOT_PATH, "libqrexec")
         env["VCHAN_DOMAIN"] = str(self.domain)
@@ -1193,8 +1206,8 @@ class TestClientVm(unittest.TestCase):
         self.client = subprocess.Popen(
             cmd,
             env=env,
-            stdin=subprocess.PIPE,
-            stdout=subprocess.PIPE,
+            stdin=stdio,
+            stdout=stdio,
             stderr=subprocess.PIPE,
             pass_fds=(stderr_dup,),
         )
@@ -1219,7 +1232,7 @@ class TestClientVm(unittest.TestCase):
         self.addCleanup(target_client.close)
         return target_client
 
-    def run_service(self, *, local_program=None, options=None):
+    def run_service(self, *, local_program=None, options=None, stdio=subprocess.PIPE):
         server = self.connect_server()
 
         args = options or []
@@ -1228,7 +1241,7 @@ class TestClientVm(unittest.TestCase):
         if local_program:
             args += local_program
 
-        self.start_client(args)
+        self.start_client(args, stdio=stdio)
         server.accept()
 
         message_type, data = server.recv_message()
@@ -1251,6 +1264,30 @@ class TestClientVm(unittest.TestCase):
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"stdout data\n")
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"")
         self.assertEqual(self.client.stdout.read(), b"stdout data\n")
+        target_client.send_message(
+            qrexec.MSG_DATA_EXIT_CODE, struct.pack("<L", 42)
+        )
+        self.client.wait()
+        self.assertEqual(self.client.returncode, 42)
+
+    def test_run_client_eof(self):
+        remote, local = socket.socketpair()
+        target_client = self.run_service(stdio=remote)
+        remote.close()
+        initial_data = b"stdout data\n"
+        target_client.send_message(qrexec.MSG_DATA_STDOUT, initial_data)
+        # FIXME: data can be received in multiple messages
+        self.assertEqual(local.recv(len(initial_data)), initial_data)
+        initial_data = b"stdin data\n"
+        local.sendall(initial_data)
+        self.assertStdoutMessages(target_client, initial_data, qrexec.MSG_DATA_STDIN)
+        target_client.send_message(qrexec.MSG_DATA_STDOUT, b"")
+        # Check that EOF got propagated
+        self.assertEqual(local.recv(1), b"")
+        # Close local
+        local.close()
+        # Check that EOF got propagated on this side too
+        self.assertEqual(target_client.recv_message(), (qrexec.MSG_DATA_STDIN, b""))
         target_client.send_message(
             qrexec.MSG_DATA_EXIT_CODE, struct.pack("<L", 42)
         )
@@ -1301,10 +1338,7 @@ class TestClientVm(unittest.TestCase):
         target_client = self.run_service(local_program=["/bin/cat"])
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"stdout data\n")
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"")
-        self.assertEqual(
-            target_client.recv_message(),
-            (qrexec.MSG_DATA_STDIN, b"stdout data\n"),
-        )
+        self.assertStdoutMessages(target_client, b"stdout data\n", qrexec.MSG_DATA_STDIN)
         self.assertEqual(
             target_client.recv_message(), (qrexec.MSG_DATA_STDIN, b"")
         )
@@ -1331,16 +1365,12 @@ echo "received: $x" >&0
 """,
             ]
         )
-        self.assertEqual(
-            target.recv_message(), (qrexec.MSG_DATA_STDIN, b"hello world\n")
-        )
+        self.assertStdoutMessages(target, b"hello world\n", qrexec.MSG_DATA_STDIN)
 
         target.send_message(qrexec.MSG_DATA_STDOUT, b"stdin\n")
         target.send_message(qrexec.MSG_DATA_STDOUT, b"")
 
-        self.assertEqual(
-            target.recv_message(), (qrexec.MSG_DATA_STDIN, b"received: stdin\n")
-        )
+        self.assertStdoutMessages(target, b"received: stdin\n", qrexec.MSG_DATA_STDIN)
         self.assertEqual(target.recv_message(), (qrexec.MSG_DATA_STDIN, b""))
 
         target.send_message(qrexec.MSG_DATA_EXIT_CODE, struct.pack("<L", 42))
@@ -1412,10 +1442,7 @@ echo "received: $x" >&0
         target_client = self.run_service()
         self.client.stdin.write(b"stdin data\n")
         self.client.stdin.flush()
-        self.assertEqual(
-            target_client.recv_message(),
-            (qrexec.MSG_DATA_STDIN, b"stdin data\n"),
-        )
+        self.assertStdoutMessages(target_client, b"stdin data\n", qrexec.MSG_DATA_STDIN)
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"stdout data\n")
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"")
         self.assertEqual(self.client.stdout.read(), b"stdout data\n")
@@ -1427,10 +1454,7 @@ echo "received: $x" >&0
     def test_run_client_with_local_proc_disconnect(self):
         target_client = self.run_service(local_program=["/bin/cat"])
         target_client.send_message(qrexec.MSG_DATA_STDOUT, b"stdout data\n")
-        self.assertEqual(
-            target_client.recv_message(),
-            (qrexec.MSG_DATA_STDIN, b"stdout data\n"),
-        )
+        self.assertStdoutMessages(target_client, b"stdout data\n", qrexec.MSG_DATA_STDIN)
         target_client.close()
         self.client.wait()
         self.assertEqual(self.client.returncode, 255)


### PR DESCRIPTION
use_stdio_socket means that stdin and stdout FDs use the same file description, which is certainly the case for socket-based services. Before this change, it was set to false in this case.  This would cause the file description to be made blocking while it is still in use, potentially causing deadlocks.

git blame points to commit 0802df70eefcf5f897b3782313d01bc1bbc3712b ("Factor out process_child_io"), but I suspect the actual bug dates back as far as the introduction of socket-based services in 76697e30f6e19bb003d669e5bdcb4dae739ac878 ("Working socket-based qrexec").

Fixes: QubesOS/qubes-issues#9169