### PR TITLE
Ensure proper RPM dependency ordering

### DIFF
--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -44,6 +44,9 @@ Requires:   python3
 Requires:   python3-inotify
 Requires:   qubes-core-dom0 >= 4.1.9
 Requires:   qubes-core-qrexec = %{version}-%{release}
+# The library is backwards compatible (new library works with old programs)
+# but not forwards compatible (old library does not work with new programs)
+Requires:   qubes-core-qrexec-libs >= %{version}-%{release}
 
 # changed qubesd socket protocol
 Conflicts:  qubes-core-dom0 < 4.1.12

--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -42,6 +42,9 @@ BuildRequires:	systemd-devel
 
 Requires:   python%{python3_pkgversion}
 Requires:   qubes-core-qrexec = %{version}-%{release}
+# The library is backwards compatible (new library works with old programs)
+# but not forwards compatible (old library does not work with new programs)
+Requires:   qubes-core-qrexec-libs >= %{version}-%{release}
 
 Provides:   qubes-core-agent-qrexec = 4.1.0-1
 Obsoletes:  qubes-core-agent-qrexec < 4.1.0-1


### PR DESCRIPTION
Old command line tools work with a new qrexec library so long as the library SONAME matches, but new command line tools will not work with an older library.  Add an explicit dependency to enforce ordering.

Fixes: QubesOS/qubes-issues#9184