### PR TITLE
Fix build error on redefined _FORTIFY_SOURCE

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -5,18 +5,18 @@ DESTDIR ?= /
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
 HAVE_PAM_APPL = $(or $(and $(wildcard /usr/include/security/pam_appl.h),1),)
 .SUFFIXES:
-override os := $(shell lsb_release -is)
-override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
-   $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-	-D_GNU_SOURCE $(CFLAGS) $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM) \
+os := $(shell lsb_release -is)
+CFLAGS += -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
+    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
+    -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+	-D_GNU_SOURCE $(if $(HAVE_PAM_APPL),-DHAVE_PAM,-UHAVE_PAM) \
 	-Wstrict-prototypes -Wold-style-definition -Wmissing-declarations -Werror=vla
-override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
-override LDLIBS=-lqrexec-utils $(shell pkg-config --libs $(VCHAN_PKG)) $(if $(HAVE_PAM_APPL),-lpam,)
+LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
+LDLIBS += -lqrexec-utils $(shell pkg-config --libs $(VCHAN_PKG)) $(if $(HAVE_PAM_APPL),-lpam,)
 
 .PHONY: all clean install
 
-override remove_generated := \
+remove_generated := \
 	rm -f -- *.o *~ qrexec-agent qrexec-client-vm *.o.dep *.gcda *.gcno
 
 all: qrexec-agent qrexec-client-vm qrexec-fork-server qrexec-client-vm.1.gz
@@ -64,6 +64,6 @@ endif
 	$(CC) $(LDFLAGS) -pie -g -o $@ $^ $(LDLIBS)
 
 %.o: %.c
-	$(CC) $< -c -o $@ $(QUBES_CFLAGS) $(CFLAGS) -MD -MP -MF $@.dep
+	$(CC) $< -c -o $@ $(CFLAGS) -MD -MP -MF $@.dep
 
 -include *.o.dep

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,13 +1,13 @@
 CC ?=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
-override QUBES_CFLAGS:=-I../libqrexec -g -O2 -Wall -Wextra -Werror -fPIC \
+CFLAGS += -I../libqrexec -g -O2 -Wall -Wextra -Werror -fPIC \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-   -D_GNU_SOURCE $(CFLAGS) \
+   -fstack-protector-strong -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+   -D_GNU_SOURCE \
    -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations \
    -fvisibility=hidden -fno-strict-aliasing -Wvla
-override LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
-override LDLIBS += $(shell pkg-config --libs $(VCHAN_PKG)) -lqrexec-utils
+LDFLAGS += -pie -Wl,-z,relro,-z,now -L../libqrexec
+LDLIBS += $(shell pkg-config --libs $(VCHAN_PKG)) -lqrexec-utils
 
 MAKEFLAGS := -r
 .SUFFIXES:
@@ -27,6 +27,6 @@ qrexec-daemon qrexec-client: %: %.o qrexec-daemon-common.o
 	$(CC) $(LDFLAGS) -pie -g -o $@ $^ $(LDLIBS)
 
 %.o: %.c
-	$(CC) $< -c -o $@ $(QUBES_CFLAGS) -MD -MP -MF $@.dep
+	$(CC) $< -c -o $@ $(CFLAGS) -MD -MP -MF $@.dep
 
 -include *.o.dep

--- a/libqrexec/Makefile
+++ b/libqrexec/Makefile
@@ -1,17 +1,17 @@
 CC ?=gcc
 VCHAN_PKG = $(if $(BACKEND_VMM),vchan-$(BACKEND_VMM),vchan)
-override QUBES_CFLAGS := -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
+CFLAGS += -I. -I../libqrexec -g -O2 -Wall -Wextra -Werror \
    $(shell pkg-config --cflags $(VCHAN_PKG)) -fstack-protector \
-   -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
-   -D_GNU_SOURCE $(CFLAGS) \
+   -fstack-protector-strong -fPIC -std=gnu11 -D_POSIX_C_SOURCE=200809L \
+   -D_GNU_SOURCE \
    -Wstrict-prototypes -Wold-style-definition -Wmissing-declarations \
    -fno-delete-null-pointer-checks -fvisibility=hidden \
    -Wvla -Wformat=2
 
-override LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
+LDFLAGS += -pie -Wl,-z,relro,-z,now -shared
 
-override SO_VER=3
-override VCHANLIBS := $(shell pkg-config --libs vchan)
+SO_VER=3
+VCHANLIBS := $(shell pkg-config --libs vchan)
 LIBDIR ?= /usr/lib
 INCLUDEDIR ?= /usr/include
 
@@ -42,6 +42,6 @@ install:
 	install -m 0644 qrexec.h $(DESTDIR)$(INCLUDEDIR)
 
 %.o: %.c
-	$(CC) $< -c -o $@ $(QUBES_CFLAGS) $(CFLAGS) -MD -MP -MF $@.dep
+	$(CC) $< -c -o $@ $(CFLAGS) -MD -MP -MF $@.dep
 
 -include *.o.dep


### PR DESCRIPTION
Leave it for the package builder to define, according to the policy of
specific distribution. And also, do not fight with provided environment,
try to play along instead - drop "override" and custom variables. This
also avoids including $(CFLAGS) twice. This rollback some of the changes
in b883dcb "Makefile improvements"

https://github.com/QubesOS/qubes-builder-archlinux/pull/73#issuecomment-2089227995