### PR TITLE
Add support for exiting on stdin or stdout EOF     

### DIFF
--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -283,8 +283,12 @@ static int handle_new_process_common(
 
     exit_code = process_io(&req);
 
-    if (type == MSG_EXEC_CMDLINE)
-        LOG(INFO, "pid %d exited with %d", pid, exit_code);
+    if (type == MSG_EXEC_CMDLINE) {
+        if (pid > 0)
+            LOG(INFO, "pid %d exited with %d", pid, exit_code);
+        else
+            LOG(INFO, "Socket service closed");
+    }
 
     libvchan_close(data_vchan);
     return exit_code;

--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -322,7 +322,7 @@ pid_t handle_new_process(int type, int connect_domain, int connect_port,
 /* Returns exit code of remote process */
 int handle_data_client(
     int type, int connect_domain, int connect_port,
-    int stdin_fd, int stdout_fd, int stderr_fd, int buffer_size, pid_t pid,
+    int stdin_fd, int stdout_fd, int buffer_size, pid_t pid,
     const char *extra_data)
 {
     int exit_code;
@@ -362,7 +362,7 @@ int handle_data_client(
 
     req.stdin_fd = stdin_fd;
     req.stdout_fd = stdout_fd;
-    req.stderr_fd = stderr_fd;
+    req.stderr_fd = -1;
     req.local_pid = pid;
 
     req.is_service = false;

--- a/agent/qrexec-agent-data.c
+++ b/agent/qrexec-agent-data.c
@@ -281,7 +281,7 @@ static int handle_new_process_common(
     req.prefix_data.data = NULL;
     req.prefix_data.len = 0;
 
-    exit_code = process_io(&req);
+    exit_code = qrexec_process_io(&req, cmd);
 
     if (type == MSG_EXEC_CMDLINE) {
         if (pid > 0)
@@ -382,7 +382,7 @@ int handle_data_client(
         req.prefix_data.len = 0;
     }
 
-    exit_code = process_io(&req);
+    exit_code = qrexec_process_io(&req, NULL);
     libvchan_close(data_vchan);
     return exit_code;
 }

--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -648,9 +648,8 @@ static void handle_server_exec_request_do(int type,
         return;
     }
 
-    /* Fork server does not load configuration, so if sending a service
-     * descriptor is not enabled, do not use it. */
-    if (cmd != NULL && !cmd->nogui && cmd->send_service_descriptor) {
+    /* Ask libqrexec-utils if the fork server is safe to use */
+    if (qrexec_cmd_use_fork_server(cmd)) {
         /* try fork server */
         int child_socket = try_fork_server(type,
                 params->connect_domain, params->connect_port,

--- a/agent/qrexec-agent.h
+++ b/agent/qrexec-agent.h
@@ -45,7 +45,7 @@ pid_t handle_new_process(int type,
         struct qrexec_parsed_command *cmd);
 int handle_data_client(int type,
         int connect_domain, int connect_port,
-        int stdin_fd, int stdout_fd, int stderr_fd,
+        int stdin_fd, int stdout_fd,
         int buffer_size, pid_t pid, const char *extra_data);
 
 

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -324,11 +324,11 @@ int main(int argc, char **argv)
 
         ret = handle_data_client(MSG_SERVICE_CONNECT,
                 exec_params.connect_domain, exec_params.connect_port,
-                inpipe[1], outpipe[0], -1, buffer_size, child_pid, prefix_data);
+                inpipe[1], outpipe[0], buffer_size, child_pid, prefix_data);
     } else {
         ret = handle_data_client(MSG_SERVICE_CONNECT,
                 exec_params.connect_domain, exec_params.connect_port,
-                stdout_fd, 0, -1, buffer_size, 0, prefix_data);
+                stdout_fd, 0, buffer_size, 0, prefix_data);
     }
 
     close(trigger_fd);

--- a/agent/qrexec-client-vm.c
+++ b/agent/qrexec-client-vm.c
@@ -149,7 +149,7 @@ int main(int argc, char **argv)
 
     setup_logging("qrexec-client-vm");
 
-    // TODO: this should be in process_io
+    // TODO: this should be in qrexec_process_io
     signal(SIGPIPE, SIG_IGN);
 
     while (1) {

--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -303,6 +303,8 @@ int main(int argc, char **argv)
                     prepare_ret = QREXEC_EXIT_PROBLEM;
                 else {
                     prepare_ret = prepare_local_fds(command, &stdin_buffer);
+                    /* Don't pass this to handshake_and_go() as this is not
+                     * a service call to dom0. */
                     destroy_qrexec_parsed_command(command);
                 }
             } else {
@@ -333,7 +335,7 @@ int main(int argc, char **argv)
                 .replace_chars_stdout = replace_chars_stdout,
                 .replace_chars_stderr = replace_chars_stderr,
             };
-            rc = handshake_and_go(&params);
+            rc = handshake_and_go(&params, NULL);
 cleanup:
             if (kill && domname) {
                 size_t l;

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -33,7 +33,8 @@ struct handshake_params {
     bool replace_chars_stderr;
 };
 __attribute__((warn_unused_result))
-int handshake_and_go(struct handshake_params *params);
+int handshake_and_go(struct handshake_params *params,
+                     const struct qrexec_parsed_command *cmd);
 __attribute__((warn_unused_result))
 int handle_agent_handshake(libvchan_t *vchan, bool remote_send_first);
 __attribute__((warn_unused_result))

--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1541,12 +1541,10 @@ int main(int argc, char **argv)
         int null_fd = open("/dev/null", O_RDONLY|O_NOCTTY);
         if (null_fd < 0)
             err(1, "open(%s)", "/dev/null");
-        if (null_fd > 0) {
-            if (dup2(null_fd, 0) != 0)
-                err(1, "dup2(%d, 0)", null_fd);
-            if (null_fd > 2 && close(null_fd) != 0)
-                err(1, "close(%d)", null_fd);
-        }
+        if (dup2(null_fd, 0) != 0)
+            err(1, "dup2(%d, 0)", null_fd);
+        if (close(null_fd) != 0)
+            err(1, "close(%d)", null_fd);
     }
 
     setup_logging("qrexec-daemon");

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -327,6 +327,8 @@ static int load_service_config_raw(struct qrexec_parsed_command *cmd,
                         config_full_path, sizeof(config_full_path), NULL);
     if (ret == -1)
         return 0;
+    if (ret != 0)
+        return ret;
     return qubes_toml_config_parse(config_full_path, &cmd->wait_for_session, user,
                                    &cmd->send_service_descriptor,
                                    &cmd->exit_on_stdout_eof,

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -89,6 +89,14 @@ struct qrexec_parsed_command {
     /* Remaining fields are private to libqrexec-utils.  Do not access them
      * directly - they may change in any update. */
 
+    /* For socket-based services: Should the event loop exit on EOF from
+     * the client? */
+    bool exit_on_stdin_eof;
+
+    /* For socket-based services: Should the event loop exit on EOF from
+     * the service? */
+    bool exit_on_stdout_eof;
+
     /* Pointer to the argument, or NULL if there is no argument.
      * Same buffer as "service_descriptor". */
     char *arg;
@@ -307,9 +315,23 @@ struct process_io_request {
  * process_io_request.
  *
  * Returns intended exit code (local or remote), but calls exit() on errors.
+ *
+ * Deprecated, use qrexec_process_io() instead.
  */
-__attribute__((visibility("default")))
+__attribute__((visibility("default"), warn_unused_result))
 int process_io(const struct process_io_request *req);
+
+/*
+ * Pass IO between vchan and local FDs. See the comments for
+ * process_io_request.
+ *
+ * Returns intended exit code (local or remote), but calls exit() on errors.
+ *
+ * cmd may be NULL to use the default behavior.
+ */
+__attribute__((visibility("default"), warn_unused_result))
+int qrexec_process_io(const struct process_io_request *req,
+                      const struct qrexec_parsed_command *cmd);
 
 // Logging
 
@@ -388,4 +410,15 @@ bool qubes_sendmsg_all(struct msghdr *msg, int sock);
 __attribute__((visibility("default")))
 int qubes_wait_for_vchan_connection_with_timeout(
         libvchan_t *conn, int wait_fd, bool is_server, time_t timeout);
+
+/**
+ * Determine if the fork server should be used, even though the fork server
+ * does not load service configuration.
+ *
+ * \param cmd The command to check.
+ * \return true if the command should be executed using the fork server,
+ *         false otherwise.
+ */
+__attribute__((visibility("default")))
+bool qrexec_cmd_use_fork_server(const struct qrexec_parsed_command *cmd);
 #endif /* LIBQREXEC_UTILS_H */

--- a/libqrexec/log.c
+++ b/libqrexec/log.c
@@ -26,6 +26,8 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <err.h>
 
 #include "libqrexec-utils.h"
 
@@ -79,5 +81,12 @@ void qrexec_log(int level, int errnoval, const char *file, int line,
 }
 
 void setup_logging(const char *program_name) {
+    /* Make sure FD 0, 1 and 2 are open.  Various code that manipulates
+     * FDs breaks if they are not. */
+    for (int i = 0; i < 3; ++i) {
+        if (fcntl(i, F_GETFD) == -1 && errno == EBADF)
+            errx(125, "File descriptor %d is closed, cannot continue", i);
+    }
+
     qrexec_program_name = program_name;
 }

--- a/libqrexec/private.h
+++ b/libqrexec/private.h
@@ -1,2 +1,7 @@
+#pragma once
 #include <stdbool.h>
-int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user, bool *skip_service_descriptor);
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session,
+                            char **user,
+                            bool *send_service_descriptor,
+                            bool *exit_on_stdout_eof,
+                            bool *exit_on_stdin_eof);

--- a/libqrexec/toml.c
+++ b/libqrexec/toml.c
@@ -171,7 +171,8 @@ static void toml_value_free(union toml_data *value, enum toml_type ty) {
     }
 }
 
-int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user, bool *send_service_descriptor)
+int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session, char **user, bool *send_service_descriptor,
+                            bool *exit_on_service_eof, bool *exit_on_client_eof)
 {
     int result = -1; /* assume problem */
     FILE *config_file = fopen(config_full_path, "re");
@@ -187,6 +188,8 @@ int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session
     bool seen_wait_for_session = false;
     bool seen_user = false;
     bool seen_skip_service_descriptor = false;
+    bool seen_exit_on_client_eof = false;
+    bool seen_exit_on_service_eof = false;
     *wait_for_session = 0;
     *send_service_descriptor = true;
 #define CHECK_DUP_KEY(v) do {                                               \
@@ -290,6 +293,14 @@ int qubes_toml_config_parse(const char *config_full_path, bool *wait_for_session
                 CHECK_TYPE(TOML_TYPE_BOOL, "wait-for-session");
                 *wait_for_session = value.boolean;
             }
+        } else if (strcmp(current_line, "exit-on-client-eof") == 0) {
+            CHECK_DUP_KEY(seen_exit_on_client_eof);
+            CHECK_TYPE(TOML_TYPE_BOOL, "exit-on-client-eof");
+            *exit_on_client_eof = value.boolean;
+        } else if (strcmp(current_line, "exit-on-service-eof") == 0) {
+            CHECK_DUP_KEY(seen_exit_on_service_eof);
+            CHECK_TYPE(TOML_TYPE_BOOL, "exit-on-service-eof");
+            *exit_on_service_eof = value.boolean;
         } else if (strcmp(current_line, "skip-service-descriptor") == 0) {
             CHECK_DUP_KEY(seen_skip_service_descriptor);
             CHECK_TYPE(TOML_TYPE_BOOL, "skip-service-descriptor");

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -561,6 +561,21 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
             os.symlink("/dev/null/doesnotexist", config_path)
         self._test_exec_service_fail()
 
+    def test_exec_service_with_invalid_config_path(self):
+        util.make_executable_service(
+            self.tempdir,
+            "rpc",
+            "qubes.Service",
+            """\
+#!/bin/sh
+echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
+""",
+        )
+        config_path = os.path.join(self.tempdir, "rpc-config")
+        os.rmdir(config_path)
+        os.symlink("/dev/null/doesnotexist", config_path)
+        self._test_exec_service_fail()
+
     def test_exec_service_with_invalid_config_1(self):
         self.exec_service_with_invalid_config("wait-for-session = 00\n")
 

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -532,7 +532,6 @@ wait-for-session = 1 # line comment
 
     def _test_exec_service_fail(self, exit_code=qrexec.QREXEC_EXIT_PROBLEM):
         target, dom0 = self.execute_qubesrpc("qubes.Service+arg", "domX")
-        target.send_message(qrexec.MSG_DATA_STDIN, b"")
         messages = target.recv_all_messages()
         self.assertListEqual(
             util.sort_messages(messages),

--- a/qrexec/tests/socket/qrexec.py
+++ b/qrexec/tests/socket/qrexec.py
@@ -117,6 +117,8 @@ class QrexecServer(QrexecClient):
         self.server_conn.close()
         self.server_conn = None
 
+    def shutdown(self, arg):
+        self.conn.shutdown(arg)
 
 def vchan_client(socket_dir, domain, remote_domain, port):
     vchan_socket_path = os.path.join(


### PR DESCRIPTION
This adds two new boolean service configuration options:
    
- exit-on-stdout-eof: exit when the socket service shuts down its output stream for writing.
- exit-on-stdin-eof: exit when the client sends EOF.

To avoid compatibility problems, global variables are used to pass this information from the configuration parser to the I/O code.  In the future, there should be a better way to pass this information, but this is not possible without more extensive changes.  Fortunately, the configuration parser only runs once in the life of any process right now, so this commit adds assertions to check this.  Qubes OS ships with assertions enabled, so any violation of this rule will be detected.
    
The main use of these features is to emulate the old qubes.ConnectTCP and qubes.UpdatesProxy services, which already had this behavior due to the use of socat.
    
These features are only supported for socket-based services, as executable services are more complicated and do not have a use case right now.
    
Currently, if a service exits due to exit-on-stdin-eof, the empty MSG_DATA_STDOUT that indicates EOF is not sent.  This is not a problem because qrexec-client-vm interprets MSG_DATA_EXIT_CODE as also indicating EOF on stdout and stderr.
    
Fixes: QubesOS/qubes-issues#9176
