### PR TITLE
Mute pylint false positive

### DIFF
--- a/qrexec/tools/qrexec_policy_exec.py
+++ b/qrexec/tools/qrexec_policy_exec.py
@@ -293,6 +293,7 @@ def get_result(args: Optional[List[str]]) -> Union[str, int]:
                                         "admin.vm.CreateDisposable")
                            .decode("ascii", "strict"))
         utils.qubesd_call(target, "admin.vm.Start")
+    # pylint: disable=possibly-used-before-assignment
     return subprocess.call((
         QREXEC_CLIENT,
         "-EWkd" if dispvm else "-Ed",


### PR DESCRIPTION
The case where process_id and domain_id are not set do result in earlier
return (due to no_exec=True).