### PR TITLE
Always send EOF on streams

### DIFF
--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -386,9 +386,15 @@ int prepare_local_fds(struct qrexec_parsed_command *command, struct buffer *stdi
 // See also qrexec-agent/qrexec-agent-data.c
 static void handle_failed_exec(libvchan_t *data_vchan, bool is_service, int exit_code)
 {
-    struct msg_header hdr = {
-        .type = MSG_DATA_STDOUT,
-        .len = 0,
+    const struct msg_header hdr[2] = {
+        {
+            .type = MSG_DATA_STDERR,
+            .len = 0,
+        },
+        {
+            .type = MSG_DATA_STDOUT,
+            .len = 0,
+        },
     };
 
     LOG(ERROR, "failed to spawn process, exiting");
@@ -404,7 +410,7 @@ static void handle_failed_exec(libvchan_t *data_vchan, bool is_service, int exit
      * when we support sockets as a local process.
      */
     if (is_service) {
-        libvchan_send(data_vchan, &hdr, sizeof(hdr));
+        libvchan_send(data_vchan, hdr, sizeof(hdr));
         send_exit_code(data_vchan, exit_code);
     }
 }

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -333,6 +333,11 @@ int qrexec_process_io(const struct process_io_request *req,
                  * local FDs. However, don't exit yet, because there might
                  * still be some data in stdin_buf waiting to be flushed.
                  */
+                if (stdout_fd != -1) {
+                    /* Send EOF */
+                    struct msg_header hdr = { .type = stdout_msg_type, .len = 0, };
+                    libvchan_send(vchan, &hdr, (int)sizeof(hdr));
+                }
                 close_stdout();
                 close_stderr(stderr_fd);
                 stderr_fd = -1;

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -339,8 +339,6 @@ int qrexec_process_io(const struct process_io_request *req,
                     libvchan_send(vchan, &hdr, (int)sizeof(hdr));
                 }
                 close_stdout();
-                close_stderr(stderr_fd);
-                stderr_fd = -1;
                 break;
         }
         if (prefix.len > 0 || (stdout_fd >= 0 && fds[FD_STDOUT].revents)) {

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -169,6 +169,14 @@ int qrexec_process_io(const struct process_io_request *req,
     /* Convenience macros that eliminate a ton of error-prone boilerplate */
 #define close_stdin() do {                                      \
     if (exit_on_stdin_eof) {                                    \
+        /* If stdout is still open, send EOF */                 \
+        if (stdout_fd != -1) {                                  \
+            const struct msg_header hdr = {                     \
+                .type = stdout_msg_type,                        \
+                .len = 0,                                       \
+            };                                                  \
+            libvchan_send(vchan, &hdr, sizeof(hdr));            \
+        };                                                      \
         /* Set stdin_fd and stdout_fd to -1.                    \
          * No need to close them as the process                 \
          * will soon exit. */                                   \

--- a/libqrexec/process_io.c
+++ b/libqrexec/process_io.c
@@ -124,6 +124,11 @@ int qrexec_process_io(const struct process_io_request *req,
     struct timespec normal_timeout = { 10, 0 };
     struct prefix_data empty = { 0, 0 }, prefix = req->prefix_data;
 
+    if (is_service && stderr_fd == -1) {
+        struct msg_header hdr = { .type = MSG_DATA_STDERR, .len = 0 };
+        libvchan_send(vchan, &hdr, (int)sizeof(hdr));
+    }
+
     struct buffer remote_buffer = {
         .data = malloc(max_chunk_size),
         .buflen = max_chunk_size,

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -758,6 +758,7 @@ exit-on-client-eof = true
         self.assertEqual(target.recv_all_messages(),
             [
                 (qrexec.MSG_DATA_STDERR, b""),
+                (qrexec.MSG_DATA_STDOUT, b""),
                 (qrexec.MSG_DATA_EXIT_CODE, b"\0\0\0\0"),
             ])
         self.check_dom0(dom0)

--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -768,6 +768,7 @@ class TestClient(unittest.TestCase):
 
         source.accept()
         source.handshake()
+        self.assertEqual(source.recv_message(), (qrexec.MSG_DATA_STDERR, b""))
         return source
 
     def test_run_dom0_command_and_connect_vm(self):


### PR DESCRIPTION
Previously, this was not guaranteed to happen if the process was exiting, and neither dom0 nor socket services would send a `MSG_DATA_STDERR`.

Fixes: QubesOS/qubes-issues#9142
Fixes: QubesOS/qubes-issues#9248
Fixes: QubesOS/qubes-issues#9249