### PR TITLE
Downgrade errors about incompatible service config to warnings

### DIFF
--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -748,21 +748,21 @@ int find_qrexec_service(
     if (euidaccess(path_buffer.data, X_OK) == 0) {
         /* Executable-based service. */
         if (!cmd->send_service_descriptor) {
-            LOG(ERROR, "Refusing to execute executable service %s with skip-service-descriptor=true",
+            LOG(WARNING, "Warning: ignoring skip-service-descriptor=true "
+                         "for execute executable service %s",
                 path_buffer.data);
-            return -2;
         }
         if (cmd->exit_on_stdout_eof) {
-            LOG(ERROR, "Refusing to execute executable service %s with "
-                       "exit-on-service-eof=true",
+            LOG(WARNING, "Warning: ignoring exit-on-service-eof=true "
+                         "for executable service %s",
                 path_buffer.data);
-            return -2;
+            cmd->exit_on_stdout_eof = false;
         }
         if (cmd->exit_on_stdin_eof) {
-            LOG(ERROR, "Refusing to execute executable service %s with "
-                       "exit-on-client-eof=true",
+            LOG(WARNING, "Warning: ignoring exit-on-client-eof=true "
+                         "for executable service %s",
                 path_buffer.data);
-            return -2;
+            cmd->exit_on_stdin_eof = false;
         }
         return 0;
     }

--- a/qrexec/tests/socket/agent.py
+++ b/qrexec/tests/socket/agent.py
@@ -433,6 +433,10 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
         ) as f:
             f.write("""\
 wait-for-session = 0
+# should be ignored for executable service
+exit-on-service-eof = true
+exit-on-client-eof = true
+skip-service-descriptor = true
 """)
         target, dom0 = self.execute_qubesrpc("qubes.Service+arg", "domX")
         target.send_message(qrexec.MSG_DATA_STDIN, b"")
@@ -593,18 +597,6 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN"
 
     def test_exec_service_with_invalid_config_6(self):
         self.exec_service_with_invalid_config(None)
-
-    def test_exec_service_with_invalid_config_7(self):
-        # skip-service-descriptor not allowed with executable service
-        self.exec_service_with_invalid_config("skip-service-descriptor = true\n")
-
-    def test_exec_service_with_invalid_config_8(self):
-        # exit-on-service-eof not allowed with executable service
-        self.exec_service_with_invalid_config("exit-on-service-eof = true\n")
-
-    def test_exec_service_with_invalid_config_9(self):
-        # exit-on-client-eof not allowed with executable service
-        self.exec_service_with_invalid_config("exit-on-client-eof = true\n")
 
     def test_exec_service_with_arg(self):
         self.make_executable_service(


### PR DESCRIPTION
If service type is changed from socket to executable, some config
options are not applicable anymore. Do not fail execution but just log a
warning. This is also relevant for migration in the other direction - if
user has an executable service that is updated to a socket service, user
may want preserve the executable variant (which is also done by the
package manager if user has modified said service) - in which case, the
config for socket variant should not prevent this configuration from
working.

This has been reported to happen with qubes.UpdatesProxy service.

Fixes QubesOS/qubes-issues#9299