### PR TITLE
pylint: deal with too-many-positional-arguments

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -723,6 +723,7 @@ class AskResolution(AbstractResolution):
     def __init__(self,
                  rule: "Rule",
                  request: "Request",
+                 *,
                  # targets for the user to choose from
                  targets_for_ask: Sequence[str],
                  # default target, or None
@@ -913,7 +914,7 @@ class ActionType(metaclass=abc.ABCMeta):
 
 class Deny(ActionType):
     # pylint: disable=missing-docstring
-    def __init__(self, rule: "Rule", notify: Optional[bool]=None):
+    def __init__(self, rule: "Rule", *, notify: Optional[bool]=None):
         super().__init__(rule)
         self.notify = True if notify is None else notify
 
@@ -950,6 +951,7 @@ class Allow(ActionType):
     def __init__(
         self,
         rule: "Rule",
+        *,
         target: Optional[str]=None,
         user: Optional[str] = None,
         notify: bool = False,
@@ -1033,6 +1035,7 @@ class Ask(ActionType):
     def __init__(
         self,
         rule: "Rule",
+        *,
         target: Optional[str]=None,
         default_target: Optional[str]=None,
         user: Optional[str] = None,
@@ -1139,7 +1142,7 @@ class Rule:
     :py:meth:`from_line_service()`.
     """
 
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes,too-many-positional-arguments
 
     action: Union[Allow, Deny, Ask]
     def __init__(

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -206,26 +206,6 @@ class TestPolicyDaemon:
         )
 
     @pytest.mark.asyncio
-    async def test_unfinished_request(
-        self, mock_request, async_server, tmp_path
-    ):
-
-        data = b"unfinished"
-
-        task = self.send_data(async_server, tmp_path, data)
-
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(task, timeout=2)
-
-        for task in asyncio.all_tasks():
-            task.cancel()
-
-        with suppress(asyncio.CancelledError):
-            await asyncio.sleep(1)
-
-        mock_request.assert_not_called()
-
-    @pytest.mark.asyncio
     async def test_too_short_request(
         self, mock_request, async_server, tmp_path
     ):

--- a/qrexec/tests/qrexec_policy_daemon.py
+++ b/qrexec/tests/qrexec_policy_daemon.py
@@ -89,10 +89,10 @@ class TestPolicyDaemon:
         eval_server = await asyncio.start_unix_server(
             functools.partial(
                 qrexec_policy_daemon.handle_qrexec_connection,
-                log,
-                mock_policy,
-                False,
-                b"policy.EvalSimple",
+                log=log,
+                policy_cache=mock_policy,
+                check_gui=False,
+                service_name=b"policy.EvalSimple",
             ),
             path=str(tmp_path / "socket.Simple"),
         )
@@ -100,10 +100,10 @@ class TestPolicyDaemon:
         gui_server = await asyncio.start_unix_server(
             functools.partial(
                 qrexec_policy_daemon.handle_qrexec_connection,
-                log,
-                mock_policy,
-                True,
-                b"policy.EvalGUI",
+                log=log,
+                policy_cache=mock_policy,
+                check_gui=True,
+                service_name=b"policy.EvalGUI",
             ),
             path=str(tmp_path / "socket.GUI"),
         )

--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -435,7 +435,7 @@ class RPCConfirmationWindow:
     def __init__(
         self, entries_info, source, service, argument, targets_list, target=None
     ):
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         sanitize_domain_name(source, assert_sanitized=True)
         sanitize_service_name(service, assert_sanitized=True)
 
@@ -521,7 +521,7 @@ class RPCConfirmationWindow:
 async def confirm_rpc(
     entries_info, source, service, argument, targets_list, target=None
 ):
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     window = RPCConfirmationWindow(
         entries_info, source, service, argument, targets_list, target
     )
@@ -597,7 +597,7 @@ class PolicyAgent(SocketService):
         return ""
 
     def notify(self, resolution, service, argument, source, target):
-        # pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments,too-many-positional-arguments
         if argument == "+":
             rpc = service
         else:

--- a/qrexec/tools/qrexec_policy_daemon.py
+++ b/qrexec/tools/qrexec_policy_daemon.py
@@ -164,7 +164,7 @@ async def _extract_qrexec_parameters(reader):
     return invoked_service, service_argument, remote_domain
 
 
-# pylint: disable=too-many-return-statements,too-many-arguments
+# pylint: disable=too-many-return-statements,too-many-arguments,too-many-positional-arguments
 async def qrexec_policy_eval(
     log,
     policy_cache,
@@ -254,7 +254,7 @@ async def qrexec_policy_eval(
 
 # pylint: disable=too-many-arguments
 async def handle_qrexec_connection(
-    log, policy_cache, check_gui, service_name, reader, writer
+    reader, writer, *, log, policy_cache, check_gui, service_name
 ):
 
     """
@@ -311,17 +311,21 @@ async def start_serving(args=None):
     eval_server = await asyncio.start_unix_server(
         functools.partial(
             handle_qrexec_connection,
-            log,
-            policy_cache,
-            False,
-            b"policy.EvalSimple",
+            log=log,
+            policy_cache=policy_cache,
+            check_gui=False,
+            service_name=b"policy.EvalSimple",
         ),
         path=args.eval_socket_path,
     )
 
     gui_eval_server = await asyncio.start_unix_server(
         functools.partial(
-            handle_qrexec_connection, log, policy_cache, True, b"policy.EvalGUI"
+            handle_qrexec_connection,
+            log=log,
+            policy_cache=policy_cache,
+            check_gui=True,
+            service_name=b"policy.EvalGUI"
         ),
         path=args.gui_socket_path,
     )

--- a/qrexec/tools/qrexec_policy_exec.py
+++ b/qrexec/tools/qrexec_policy_exec.py
@@ -323,6 +323,7 @@ async def handle_request(
     intended_target: str,
     service_and_arg: str,
     log,
+    *,
     just_evaluate: bool = False,
     assume_yes_for_ask: bool = False,
     allow_resolution_type: Optional[type]=None,


### PR DESCRIPTION
Convert to keyword-only arguments where it makes sense and disable
warning in other places.