### PR TITLE
Implement UUID support in qrexec (resolve conflict in #135)

### DIFF
--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -259,7 +259,7 @@ int main(int argc, char **argv)
         usage(argv[0]);
     }
 
-    if (strcmp(domname, "dom0") == 0 || strcmp(domname, "@adminvm") == 0) {
+    if (target_refers_to_dom0(domname)) {
         if (request_id == NULL) {
             fprintf(stderr, "ERROR: when target domain is 'dom0', -c must be specified\n");
             usage(argv[0]);
@@ -278,10 +278,11 @@ int main(int argc, char **argv)
                            exit_with_code);
     } else {
         if (request_id) {
+            bool const use_uuid = strncmp(domname, "uuid:", 5) == 0;
             rc = qrexec_execute_vm(domname, false, src_domain_id,
                                    remote_cmdline, strlen(remote_cmdline) + 1,
                                    request_id, just_exec,
-                                   wait_connection_end) ? 0 : 137;
+                                   wait_connection_end, use_uuid) ? 0 : 137;
         } else {
             s = connect_unix_socket(domname);
             if (!negotiate_connection_params(s,

--- a/daemon/qrexec-daemon-common.h
+++ b/daemon/qrexec-daemon-common.h
@@ -142,6 +142,8 @@ int prepare_local_fds(struct qrexec_parsed_command *command, struct buffer *stdi
 __attribute__((warn_unused_result))
 bool qrexec_execute_vm(const char *target, bool autostart, int remote_domain_id,
                        const char *cmd, size_t service_length, const char *request_id,
-                       bool just_exec, bool wait_connection_end);
+                       bool just_exec, bool wait_connection_end, bool use_uuid);
 /** FD for stdout of remote process */
 extern int local_stdin_fd;
+__attribute__((warn_unused_result))
+bool target_refers_to_dom0(const char *target);

--- a/libqrexec/libqrexec-utils.h
+++ b/libqrexec/libqrexec-utils.h
@@ -372,17 +372,33 @@ __attribute__((visibility("default")))
 void setup_logging(const char *program_name);
 
 /**
+ * Make an Admin API call to qubesd with no payload.  The returned buffer must be released by
+ * the caller using free().
+ *
+ * @param[in] dest The destination VM name.
+ * @param[in] method The method name.
+ * @param[in] arg The service argument
+ * @param[in] payload The payload of the API call.
+ * @return The value on success.  On failure returns NULL and sets errno.
+ */
+char *qubesd_call(const char *dest, char *method, char *arg, size_t *out_len);
+
+/**
  * Make an Admin API call to qubesd.  The returned buffer must be released by
  * the caller using free().
  *
- * @param dest The destination VM name.
- * @param method The method name.
- * @param arg The service argument
- * @param len The length of the data returned
+ * @param[in] dest The destination VM name.
+ * @param[in] method The method name.
+ * @param[in] arg The service argument
+ * @param[in] payload The payload of the API call.
+ * @param[in] len The length of the payload.
+ * @param[out] len The length of the data returned.
  * @return The value on success.  On failure returns NULL and sets errno.
  */
 __attribute__((visibility("default")))
 char *qubesd_call(const char *dest, char *method, char *arg, size_t *len);
+__attribute__((visibility("default")))
+char *qubesd_call2(const char *dest, char *method, char *arg, const char *payload, size_t len, size_t *out_len);
 
 /**
  * Read all data from the file descriptor until EOF, then close it.

--- a/qrexec/tests/cli.py
+++ b/qrexec/tests/cli.py
@@ -103,39 +103,46 @@ def policy():
 @pytest.fixture(autouse=True)
 def system_info():
     system_info = {
-        "domains": {
-            "dom0": {
-                "icon": "black",
-                "template_for_dispvms": False,
-                "guivm": None,
-            },
-            "source": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": "gui",
-            },
-            "test-vm1": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-            },
-            "test-vm2": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-            },
-            "test-vm3": {
-                "icon": "green",
-                "template_for_dispvms": True,
-                "guivm": None,
-            },
-            "gui": {
-                "icon": "orange",
-                "template_for_dispvms": False,
-                "guivm": None,
-            },
+        "dom0": {
+            "icon": "black",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "uuid": "00000000-0000-0000-0000-000000000000",
+        },
+        "source": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": "gui",
+            "uuid": "33e31fb2-31a3-4486-abef-e141416221d9",
+        },
+        "test-vm1": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "uuid": "42d488d0-1168-44eb-9829-81bde8f43065",
+        },
+        "test-vm2": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "uuid": "5b92449a-e783-4566-a1bc-67b6389be5cc",
+        },
+        "test-vm3": {
+            "icon": "green",
+            "template_for_dispvms": True,
+            "guivm": None,
+            "uuid": "5f3989a7-44e3-4154-bd14-7688f802ec21",
+        },
+        "gui": {
+            "icon": "orange",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "uuid": "f5c8b32b-8ade-4cdf-8b28-180e07b30ace",
         },
     }
+    for i, j in system_info.items():
+        j["name"] = i
+    system_info = {"domains": system_info}
     with mock.patch("qrexec.utils.get_system_info") as mock_system_info:
         mock_system_info.return_value = system_info
         yield system_info
@@ -209,7 +216,12 @@ def test_000_allow(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == []
 
 
@@ -218,7 +230,12 @@ def test_001_allow_notify(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == [
         notify_call("allow"),
     ]
@@ -230,7 +247,12 @@ def test_002_allow_notify_failed(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == [
         notify_call("allow"),
     ]
@@ -243,7 +265,12 @@ def test_004_allow_no_guivm(policy, system_info, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == []
 
 
@@ -253,7 +280,12 @@ def test_010_ask_allow(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == [
         ask_call(),
     ]
@@ -265,7 +297,12 @@ def test_011_ask_allow_notify(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == [
         ask_call(),
         notify_call("allow"),
@@ -278,7 +315,7 @@ def test_012_ask_allow_notify_no_argument(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == "user=user\nresult=allow\ntarget=test-vm1\ntarget_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065\nautostart=True\nrequested_target=test-vm1"
     assert agent_service.mock_calls == [
         ask_call(argument="+"),
         notify_call("allow", argument="+"),
@@ -316,7 +353,12 @@ def test_017_ask_default_target(policy, agent_service):
     retval = qrexec_policy_exec.get_result(
         ["source", "test-vm1", "service+arg"]
     )
-    assert retval == "user=user\nresult=allow\ntarget=test-vm1\nautostart=True\nrequested_target=test-vm1"
+    assert retval == """user=user
+result=allow
+target=test-vm1
+target_uuid=uuid:42d488d0-1168-44eb-9829-81bde8f43065
+autostart=True
+requested_target=test-vm1"""
     assert agent_service.mock_calls == [
         ask_call(default_target="test-vm1"),
     ]
@@ -440,14 +482,14 @@ def test_034_allow_policy_exec(policy, agent_service):
             ["source-id", "source", "test-vm1", "service+arg",
              "process_ident"]
         )
-        assert c.mock_calls == [mock.call("test-vm1", "admin.vm.Start")]
+        assert c.mock_calls == [mock.call("uuid:42d488d0-1168-44eb-9829-81bde8f43065", "admin.vm.Start")]
         assert agent_service.mock_calls == []
         assert retval == 0
         assert m.mock_calls == [
             mock.call((
                 QREXEC_CLIENT,
                 "-Ed",
-                "test-vm1",
+                "uuid:42d488d0-1168-44eb-9829-81bde8f43065",
                 "-c",
                 "process_ident,source,source-id",
                 "--",

--- a/qrexec/tests/policy_graph.py
+++ b/qrexec/tests/policy_graph.py
@@ -21,57 +21,74 @@ import tempfile
 
 import pytest
 from unittest import mock
+from types import MappingProxyType as Proxy
 
 from ..tools.qrexec_policy_graph import main
 
 @pytest.fixture(autouse=True)
 def system_info():
     system_info = {
-        "domains": {
-            "dom0": {
-                "icon": "black",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AdminVM",
-                "tags": [],
-            },
-            "work": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "personal": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "sys-usb": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "sys-usb-2": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "dvm_template": {
-                "icon": "red",
-                "template_for_dispvms": True,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
+        "dom0": {
+            "icon": "black",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AdminVM",
+            "tags": [],
+            "uuid": "00000000-0000-0000-0000-000000000000",
+        },
+        "work": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "bab9a66f-57b1-4cc3-8e8f-3d2368a8a68d",
+        },
+        "personal": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "4fe7ad96-1db2-4523-9c3d-3abc31d55427",
+        },
+        "sys-usb": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "d9f594c1-85a4-443f-81e7-aeadf0d0a8fd",
+        },
+        "sys-usb-2": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "03958b59-8ea0-43c7-9aa6-afaf4bf482f0",
+        },
+        "dvm_template": {
+            "icon": "red",
+            "template_for_dispvms": True,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "29a7a455-9d71-426f-80ed-932d381cec0a",
         },
     }
+
+    for i, j in list(system_info.items()):
+        assert not i.startswith("uuid:")
+        j["name"] = i
+        j["tags"] = tuple(j["tags"])
+        assert not j["name"].startswith("uuid:")
+        k = system_info["uuid:" + j["uuid"]] = system_info[i] = Proxy(j)
+        assert not k["name"].startswith("uuid:")
+    for i in system_info.values():
+        assert not i["name"].startswith("uuid:")
+    system_info = Proxy({"domains": system_info})
+
     with mock.patch("qrexec.utils.get_system_info") as mock_system_info:
         mock_system_info.return_value = system_info
         yield system_info

--- a/qrexec/tests/qrexec_legacy_convert.py
+++ b/qrexec/tests/qrexec_legacy_convert.py
@@ -22,56 +22,72 @@ from typing import Tuple
 from unittest import mock
 import pytest
 from pathlib import Path
+from types import MappingProxyType as Proxy
 from ..tools import qrexec_legacy_convert
 
 @pytest.fixture(autouse=True)
 def system_info():
     system_info = {
-        "domains": {
-            "dom0": {
-                "icon": "black",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AdminVM",
-                "tags": [],
-            },
-            "work": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "personal": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "sys-usb": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "sys-usb-2": {
-                "icon": "red",
-                "template_for_dispvms": False,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
-            "dvm_template": {
-                "icon": "red",
-                "template_for_dispvms": True,
-                "guivm": None,
-                "type": "AppVM",
-                "tags": [],
-            },
+        "dom0": {
+            "icon": "black",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AdminVM",
+            "tags": [],
+            "uuid": "00000000-0000-0000-0000-000000000000",
+        },
+        "work": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "8079de03-ab79-424c-8fb6-d8adcfda19d1",
+        },
+        "personal": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "bf7cdc8a-1dc5-4fcc-b01f-bd648ff8d903",
+        },
+        "sys-usb": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "46fd27ac-46e3-44d7-918e-986f095900f9",
+        },
+        "sys-usb-2": {
+            "icon": "red",
+            "template_for_dispvms": False,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "b65fceec-2d84-4665-99cb-50c2e7d91dc6",
+        },
+        "dvm_template": {
+            "icon": "red",
+            "template_for_dispvms": True,
+            "guivm": None,
+            "type": "AppVM",
+            "tags": [],
+            "uuid": "b41c5829-3ea9-475e-b5e6-b404ea409f29",
         },
     }
+
+    for i, j in list(system_info.items()):
+        assert not i.startswith("uuid:")
+        j["name"] = i
+        j["tags"] = tuple(j["tags"])
+        system_info["uuid:" + j["uuid"]] = system_info[i] = Proxy(j)
+    for i in system_info.values():
+        assert not i["name"].startswith("uuid:")
+        assert "uuid" in i
+    system_info = Proxy({"domains": system_info})
+
     with mock.patch("qrexec.utils.get_system_info") as mock_system_info:
         mock_system_info.return_value = system_info
         yield system_info

--- a/qrexec/tests/socket/qrexec.py
+++ b/qrexec/tests/socket/qrexec.py
@@ -140,22 +140,23 @@ def vchan_server(socket_dir, domain, remote_domain, port):
     return socket_server(vchan_socket_path)
 
 
-def socket_server(socket_path, socket_path_alt=None):
+def socket_server(socket_path, socket_path_alt=()):
+    assert isinstance(socket_path_alt, tuple), "did you forget the tuple?"
     try:
         os.unlink(socket_path)
     except FileNotFoundError:
         pass
-    if socket_path_alt is not None:
-        assert socket_path_alt[0] == '/', "path not absolute"
+    for i in socket_path_alt:
+        assert i[0] == '/', "path not absolute"
         try:
-            os.unlink(socket_path_alt)
+            os.unlink(i)
         except FileNotFoundError:
             pass
     server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     server.bind(socket_path)
-    if socket_path_alt is not None:
-        os.symlink(socket_path, socket_path_alt)
+    for i in socket_path_alt:
+        os.symlink(socket_path, i)
     server.listen(1)
     return QrexecServer(server)
 

--- a/qrexec/tools/qrexec_policy_exec.py
+++ b/qrexec/tools/qrexec_policy_exec.py
@@ -74,9 +74,11 @@ class AgentAskResolution(parser.AskResolution):
             assert False, "handle_user_response should throw"
 
         # prepare icons
-        icons = {name: domains[name]["icon"] for name in domains.keys()}
+        icons = {name: domains[name]["icon"] for name in domains.keys()
+                 if not name.startswith("uuid:")}
         for dispvm_base in domains:
-            if not domains[dispvm_base]["template_for_dispvms"]:
+            if (dispvm_base.startswith("uuid:")
+                or not domains[dispvm_base]["template_for_dispvms"]):
                 continue
             dispvm_api_name = "@dispvm:" + dispvm_base
             icons[dispvm_api_name] = domains[dispvm_base]["icon"]
@@ -292,10 +294,10 @@ def get_result(args: Optional[List[str]]) -> Union[str, int]:
             intended_target = intended_target[1:]
         cmd += f" {target_type} {intended_target}"
     else:
+        target = result["target_uuid"]
         cmd = f"{result['user'] or 'DEFAULT'}:" + cmd
         if dispvm:
-            target = (utils.qubesd_call(target[8:],
-                                        "admin.vm.CreateDisposable")
+            target = (utils.qubesd_call(target, "admin.vm.CreateDisposable", payload=b"uuid")
                            .decode("ascii", "strict"))
         utils.qubesd_call(target, "admin.vm.Start")
     # pylint: disable=possibly-used-before-assignment

--- a/qrexec/tools/qrexec_policy_graph.py
+++ b/qrexec/tools/qrexec_policy_graph.py
@@ -136,16 +136,18 @@ def main(args=None, output=sys.stdout):
     else:
         system_info = utils.get_system_info()
 
-    sources = list(system_info["domains"].keys())
+    targets = [key for key in system_info["domains"] if not key.startswith("uuid")]
     if args.source:
         sources = args.source
+    else:
+        sources = list(targets)
 
-    targets = list(system_info["domains"].keys())
     targets.append("@dispvm")
     targets.extend(
         "@dispvm:" + dom
         for dom in system_info["domains"]
-        if system_info["domains"][dom]["template_for_dispvms"]
+        if (not dom.startswith("uuid:")
+            and system_info["domains"][dom]["template_for_dispvms"])
     )
     targets.append("@default")
 


### PR DESCRIPTION
This allows using UUIDs in qrexec policy, using the syntax uuid:VM_UUID.
This works anywhere a VM name is expected.  Since ':' is not allowed in
VM names, there is no ambiguity.  This requires the corresponding change
to qubes-core-admin so that qubesd supports UUIDs in the admin and
internal APIs.

Fixes: QubesOS/qubes-issues#8510