### PR TITLE
rpm: adjust SELinux snippets for relabeling

### DIFF
--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -97,6 +97,9 @@ rm -f %{name}-%{version}
 %preun
 %systemd_preun qubes-qrexec-agent.service
 
+%pre selinux
+%selinux_relabel_pre
+
 %post selinux
 %selinux_modules_install %{_datadir}/selinux/packages/qubes-core-qrexec.pp || :
 


### PR DESCRIPTION
Adjust according to https://fedoraproject.org/wiki/SELinux/IndependentPolicy#Creating_the_Spec_File

Specifically, when %selinux_relabel_post is used, %selinux_relabel_pre
needs to be there too.

QubesOS/qubes-issues#9663