### PR TITLE
Ignore SIGPIPE in qrexec-fork-server too

### DIFF
--- a/agent/qrexec-fork-server.c
+++ b/agent/qrexec-fork-server.c
@@ -138,6 +138,7 @@ int main(int argc, char **argv) {
             exit(0);
     }
     signal(SIGCHLD, SIG_IGN);
+    signal(SIGPIPE, SIG_IGN);
     register_exec_func(do_exec);
 
     while (1) {


### PR DESCRIPTION
The process_io() (or more precisely - write_stdin() and write_all())
function relies on write() reporting errors "normally" (negative
return value + errno), it is not prepared to handle SIGPIPE signal. If
service exits, SIGPIPE sent to the qrexec-fork-server worker process
would kill it. The main qrexec-agent process correctly has SIGPIPE
handler set to SIG_IGN, but this was missing in qrexec-fork-server. Add
it there too.

This was found when debugging qrexec performance tests, but looks also
similar to this issue:
Fixes QubesOS/qubes-issues#5749