### PR TITLE
qrexec-agent: Require an argument to --fork-server-socket

### DIFF
--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -858,7 +858,7 @@ static void handle_terminated_fork_client(int id) {
 static struct option longopts[] = {
     { "help", no_argument, 0, 'h' },
     { "agent-socket", required_argument, 0, 'a' },
-    { "fork-server-socket", optional_argument, 0, 's' },
+    { "fork-server-socket", required_argument, 0, 's' },
     { "no-fork-server", no_argument, 0, 'S' },
     { NULL, 0, 0, 0 },
 };


### PR DESCRIPTION
Previously 'qrexec-agent --fork-server-socket' (no argument) would segfault: it calls strdup() on optarg, but if there is no argument optarg is NULL.  This doesn't change behavior for any command lines that don't currently segfault, so it is safe to backport to R4.2.

Fixes: QubesOS/qubes-issues#9778