### PR TITLE
refactor: drop gbulb dependency

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -6,4 +6,3 @@ sphinx
 pytest-asyncio
 pyinotify
 psutil
-gbulb

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends:
  dh-python,
  lsb-release,
  python3-setuptools,
- python3-gbulb,
  pandoc,
 Standards-Version: 4.4.0.1
 Homepage: https://www.qubes-os.org

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -46,7 +46,6 @@ BuildRequires:  python%{python3_pkgversion}-rpm-macros
 %endif
 
 Requires:   python%{python3_pkgversion}
-Requires:   python%{python3_pkgversion}-gbulb
 %if 0%{?is_opensuse}
 Requires:   python%{python3_pkgversion}-pyinotify
 %else

--- a/run-tests
+++ b/run-tests
@@ -2,7 +2,7 @@
 
 case $0 in (/*) cd "${0%/*}/";; (*/*) cd "./${0%/*}";; esac
 if command -v dnf >/dev/null; then
-    sudo dnf install python3dist\({coverage,pytest,gbulb,pyinotify,pytest-asyncio}\) || :
+    sudo dnf install python3dist\({coverage,pytest,pyinotify,pytest-asyncio}\) || :
 fi
 if pkg-config vchan-socket; then
     if [[ -n "${USE_ASAN-}" ]]; then


### PR DESCRIPTION
gbulb package is deprecated by upstream:
https://github.com/beeware/gbulb?tab=readme-ov-file#this-project-has-been-archived

Not sure if that is the correct way to do things, but the new implementation works on NixOS-qubes.
It seems like gobject version in qubesos is recent enough too.