### PR TITLE
rpm: drop BR: lsb-core-noarch

### DIFF
--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -37,7 +37,6 @@ BuildRequires:	pam-devel
 BuildRequires:	pandoc
 BuildRequires:	qubes-libvchan-devel
 BuildRequires:	qubes-core-qrexec-devel
-BuildRequires:	lsb-core-noarch
 BuildRequires:	systemd-devel
 
 Requires:   python%{python3_pkgversion}


### PR DESCRIPTION
It doesn't exist in F42 anymore, and appears to not really be needed.

QubesOS/qubes-issues#9807