### PR TITLE
Define additional default RPC config paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ install-base: all-base
 	install -d $(DESTDIR)/etc/xdg/autostart -m 755
 	install -m 644 policy-agent-extra/qrexec-policy-agent.desktop \
 		$(DESTDIR)/etc/xdg/autostart/qrexec-policy-agent.desktop
+	install -m 755 -d $(DESTDIR)/usr/lib/tmpfiles.d
+	install -m 644 -t $(DESTDIR)/usr/lib/tmpfiles.d/ systemd/qrexec-volatile-config.conf
 .PHONY: install-base
 
 

--- a/debian/qubes-core-qrexec.install
+++ b/debian/qubes-core-qrexec.install
@@ -22,4 +22,5 @@ usr/lib/qubes/qrexec-client-vm
 usr/lib/qubes/qrexec_client_vm
 usr/lib/qubes/qubes-rpc-multiplexer
 usr/lib/qubes/qrexec-policy-agent-autostart
+usr/lib/tmpfiles.d/qrexec-volatile-config.conf
 usr/share/man/man1/qrexec-client-vm.1.gz

--- a/libqrexec/qrexec.h
+++ b/libqrexec/qrexec.h
@@ -165,10 +165,10 @@ enum {
 #define MEMINFO_WRITER_PIDFILE "/var/run/meminfo-writer.pid"
 #define QREXEC_DAEMON_SOCKET_DIR "/var/run/qubes"
 #define QREXEC_POLICY_PROGRAM "/usr/bin/qrexec-policy-exec"
-#define QREXEC_SERVICE_PATH "/usr/local/etc/qubes-rpc:/etc/qubes-rpc"
+#define QREXEC_SERVICE_PATH "/run/qubes-rpc:/usr/local/etc/qubes-rpc:/etc/qubes-rpc"
 
 // directory for services configuration (for example 'wait-for-session' flag)
-#define QUBES_RPC_CONFIG_PATH "/etc/qubes/rpc-config"
+#define QUBES_RPC_CONFIG_PATH "/run/qubes/rpc-config:/usr/local/etc/qubes/rpc-config:/etc/qubes/rpc-config"
 // support only very small configuration files,
 #define MAX_CONFIG_SIZE 4096
 

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -44,6 +44,7 @@ BuildRequires:  python-rpm-macros
 %else
 BuildRequires:  python%{python3_pkgversion}-rpm-macros
 %endif
+BuildRequires:  systemd-rpm-macros
 
 Requires:   python%{python3_pkgversion}
 Requires:   python%{python3_pkgversion}-gbulb
@@ -142,6 +143,8 @@ rm -f %{name}-%{version}
 %{_sysconfdir}/qubes-rpc/policy.Notify
 
 %{_sysconfdir}/xdg/autostart/qrexec-policy-agent.desktop
+
+%{_tmpfilesdir}/qrexec-volatile-config.conf
 
 %dir %{python3_sitelib}/qrexec-*.egg-info
 %{python3_sitelib}/qrexec-*.egg-info/*

--- a/selinux/qubes-core-qrexec.fc
+++ b/selinux/qubes-core-qrexec.fc
@@ -1,3 +1,5 @@
 /usr/lib/qubes/qrexec-agent	--	gen_context(system_u:object_r:qubes_qrexec_agent_exec_t,s0)
 /etc/qubes-rpc(/.*)?	gen_context(system_u:object_r:bin_t,s0)
 /usr/local/etc/qubes-rpc(/.*)?	--	gen_context(system_u:object_r:bin_t,s0)
+/run/qubes/rpc-config(/.*)?	gen_context(system_u:object_r:etc_t,s0)
+/run/qubes-rpc(/.*)?	gen_context(system_u:object_r:bin_t,s0)

--- a/systemd/qrexec-volatile-config.conf
+++ b/systemd/qrexec-volatile-config.conf
@@ -1,0 +1,2 @@
+d /run/qubes/rpc-config 0755 root qubes
+d /run/qubes-rpc 0755 root qubes


### PR DESCRIPTION
Originally, libqrexec only scanned /etc/qubes/rpc-config for RPC configuration. This prevented having truly ephemeral RPC config under /run/qubes/rpc-config, and also didn't allow local configuration to be stored under /usr/local/etc/qubes/rpc-config. Add both of these paths to QUBES_RPC_CONFIG_PATH.

/run/qubes/rpc-config needs some SELinux configuration for qrexec components to be able to access it, so add the needed config for that too.

Fixes https://github.com/QubesOS/qubes-issues/issues/9824

(Note, I'm not sure I did the `/run/qubes/rpc-config` directory creation correctly - I considered using `mkdir --parents` there, but was afraid of messing up the SELinux labeling on `/run/qubes` on accident by doing that. Instead, I opted to just make `/run/qubes/rpc-config`, allow the command to fail if a parent directory didn't exist, and also set the SELinux type in the `mkdir` command rather than using `restorecon` to set it right since I felt like `restorecon` was too hacky for this. If there's a better way of doing this, I'm more than happy to change it.)