### PR TITLE
Fix protocol version negotiation on agent reconnect

### DIFF
--- a/daemon/qrexec-daemon.c
+++ b/daemon/qrexec-daemon.c
@@ -1533,7 +1533,8 @@ static int handle_agent_restart(int xid) {
         PERROR("cannot connect to qrexec agent");
         return -1;
     }
-    if (handle_agent_hello(vchan, remote_domain_name) < 0) {
+    protocol_version = handle_agent_hello(vchan, remote_domain_name);
+    if (protocol_version < 0) {
         libvchan_close(vchan);
         vchan = NULL;
         return -1;


### PR DESCRIPTION
When qrexec-agent reconnect save newly negotiated protocol version. The
agent might have been just updated.

Found while testing https://github.com/QubesOS/qubes-core-qrexec/pull/182