### PR TITLE
Add error messages to few more QREXEC_EXIT_PROBLEM cases

### DIFF
--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -276,10 +276,14 @@ _Noreturn void do_exec(const char *prog, const char *cmd, const char *user)
         case 0:
             /* child */
 
-            if (setgid (pw->pw_gid))
+            if (setgid (pw->pw_gid)) {
+                PERROR("setgid");
                 _exit(QREXEC_EXIT_PROBLEM);
-            if (setuid (pw->pw_uid))
+            }
+            if (setuid (pw->pw_uid)) {
+                PERROR("setuid");
                 _exit(QREXEC_EXIT_PROBLEM);
+            }
             setsid();
             /* This is a copy but don't care to free as we exec later anyway.  */
             env = pam_getenvlist (pamh);
@@ -296,6 +300,7 @@ _Noreturn void do_exec(const char *prog, const char *cmd, const char *user)
             }
             /* otherwise exec shell */
             execle(pw->pw_shell, arg0, "-c", cmd, (char*)NULL, env);
+            LOGE(ERROR, "exec shell");
             _exit(QREXEC_EXIT_PROBLEM);
         default:
             /* parent */
@@ -322,6 +327,7 @@ _Noreturn void do_exec(const char *prog, const char *cmd, const char *user)
 
     if (pam_end(pamh, retval) != PAM_SUCCESS) {     /* close Linux-PAM */
         pamh = NULL;
+        LOG(ERROR, "pam_end (retval %d)", retval);
         exit(QREXEC_EXIT_PROBLEM);
     }
     exit(status);

--- a/libqrexec/exec.c
+++ b/libqrexec/exec.c
@@ -161,7 +161,11 @@ void exec_qubes_rpc2(const char *program, const char *cmd, char *const envp[],
         assert(iterator <= env_amount);
         buf[iterator] = NULL;
         execve(program, (char *const *)argv, buf);
-        _exit(errno == ENOENT ? QREXEC_EXIT_SERVICE_NOT_FOUND : QREXEC_EXIT_PROBLEM);
+        if (errno != ENOENT) {
+            PERROR("execve");
+            _exit(QREXEC_EXIT_PROBLEM);
+        }
+        _exit(QREXEC_EXIT_SERVICE_NOT_FOUND);
     }
 
     // Generate a shell command and call it with the correct arguments.
@@ -208,6 +212,7 @@ void exec_qubes_rpc2(const char *program, const char *cmd, char *const envp[],
     argv[9] = NULL;
     execve("/bin/sh", (char *const *)argv, buf);
     /* /bin/sh should always exist */
+    PERROR("execve /bin/sh");
     _exit(QREXEC_EXIT_PROBLEM);
 bad_asprintf:
     PERROR("asprintf");


### PR DESCRIPTION
Tests detect that sometimes qrexec call fails with QREXEC_EXIT_PROBLEM,
but no message about the actual cause. Review all instances of
QREXEC_EXIT_PROBLEM and try to cover missing ones with an error message.