### PR TITLE
qrexec-policy-agent: Replace usage of deprecated Gtk.Entry.set_icon_from_stock

### DIFF
--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -54,15 +54,23 @@ class VMListModeler:
         self._domains_info = domains_info
         self._icons = {}
         self._icon_size = 16
+        self._find_icon = None
         self._theme = Gtk.IconTheme.get_default()
         self._create_entries()
+
+    def _get_find_icon(self):
+        if self._find_icon is None:
+            self._find_icon = self._theme.load_icon(
+                "edit-find", self._icon_size, 0
+            )
+        return self._find_icon
 
     def _get_icon(self, name):
         if name not in self._icons:
             try:
                 icon = self._theme.load_icon(name, self._icon_size, 0)
             except GLib.Error:  # pylint: disable=catching-non-exception
-                icon = self._theme.load_icon("edit-find", self._icon_size, 0)
+                icon = self._get_find_icon()
 
             self._icons[name] = icon
 
@@ -128,8 +136,8 @@ class VMListModeler:
                 )
         else:
             if entry_box:
-                entry_box.set_icon_from_stock(
-                    Gtk.EntryIconPosition.PRIMARY, "gtk-find"
+                entry_box.set_icon_from_pixbuf(
+                    Gtk.EntryIconPosition.PRIMARY, self._get_find_icon()
                 )
 
         if selection_trigger:


### PR DESCRIPTION
Gtk docs suggest set_icon_from_icon_name as replacement. But for some reason that uses another theme. So instead reuse the code from the fallback in _get_icon.