### PR TITLE
Fix TestClient::test_run_dom0_service_socket_no_read

### DIFF
--- a/qrexec/tests/socket/daemon.py
+++ b/qrexec/tests/socket/daemon.py
@@ -1318,9 +1318,9 @@ echo "arg: $1, remote domain: $QREXEC_REMOTE_DOMAIN, input: $input"
 
         def callback(source, server):
             server.sendall(b"stdout data")
-            server.close()
             source.send_message(qrexec.MSG_DATA_STDIN, b"stdin data")
             source.send_message(qrexec.MSG_DATA_STDIN, b"")
+            server.close()
 
         self._test_run_dom0_service_socket_meta(callback)
 


### PR DESCRIPTION
Don't close server before source. Otherwise the read to source can fail with "Broken pipe".

---

That is unless I misunderstood the intended behavior in this test case. In that case the implementation needs to be fixed.