### PR TITLE
Don't translate dom0 to @adminvm

### DIFF
--- a/qrexec/tests/policy_graph.py
+++ b/qrexec/tests/policy_graph.py
@@ -277,7 +277,7 @@ def test_simple_redirect():
             )
             content = output.read().decode()
             expected = """digraph g {
-  "work" -> "@adminvm" [label="test.Service" color=red];
+  "work" -> "dom0" [label="test.Service" color=red];
 }
 """
             assert content == expected

--- a/qrexec/tests/qrexec_legacy_convert.py
+++ b/qrexec/tests/qrexec_legacy_convert.py
@@ -147,7 +147,7 @@ personal @anyvm deny"""
     assert (
         result.read_text()
         == qrexec_legacy_convert.TOOL_DISCLAIMER
-        + """qubes.Filecopy\t*\t@adminvm\t@anyvm\task
+        + """qubes.Filecopy\t*\tdom0\t@anyvm\task
 qubes.Filecopy\t*\twork\t@anyvm\task
 qubes.Filecopy\t*\tpersonal\t@anyvm\tdeny
 """
@@ -273,9 +273,9 @@ sys-usb dom0 deny"""
     assert set(input_result.read_text().split("\n")) == set(
         (
             qrexec_legacy_convert.TOOL_DISCLAIMER
-            + """qubes.InputKeyboard\t*\tsys-usb\t@adminvm\task
-qubes.InputMouse\t*\tsys-usb\t@adminvm\tallow
-qubes.InputTablet\t*\tsys-usb\t@adminvm\tdeny
+            + """qubes.InputKeyboard\t*\tsys-usb\tdom0\task
+qubes.InputMouse\t*\tsys-usb\tdom0\tallow
+qubes.InputTablet\t*\tsys-usb\tdom0\tdeny
 """
         ).split("\n")
     )
@@ -293,7 +293,7 @@ def test_input_multiple_rules(
     # the deny @anyvm should be move to 30-user file
     (old_policy_dir / "qubes.InputKeyboard").write_text(
         """
-sys-usb dom0 ask default_target=@adminvm
+sys-usb dom0 ask default_target=dom0
 sys-usb @anyvm deny
 """
     )
@@ -321,9 +321,9 @@ sys-usb dom0 deny"""
     assert set(input_result.read_text().split("\n")) == set(
         (
             qrexec_legacy_convert.TOOL_DISCLAIMER
-            + """qubes.InputKeyboard\t*\tsys-usb\t@adminvm\task default_target=@adminvm
-qubes.InputMouse\t*\tsys-usb\t@adminvm\tallow
-qubes.InputTablet\t*\tsys-usb\t@adminvm\tdeny
+            + """qubes.InputKeyboard\t*\tsys-usb\tdom0\task default_target=dom0
+qubes.InputMouse\t*\tsys-usb\tdom0\tallow
+qubes.InputTablet\t*\tsys-usb\tdom0\tdeny
 """
         ).split("\n")
     )
@@ -355,9 +355,9 @@ sys-usb-2 dom0 deny
     # the sys-usb-2 @anyvm rule should go to 30-user
     (old_policy_dir / "qubes.InputMouse").write_text(
         """
-sys-usb dom0 allow
+sys-usb @adminvm allow
 sys-usb-2 @anyvm deny
-sys-usb-2 dom0 allow
+sys-usb-2 @adminvm allow
 """
     )
     # first rule goes to 50-config
@@ -379,11 +379,11 @@ sys-usb dom0 deny"""
     assert set(input_result.read_text().split("\n")) == set(
         (
             qrexec_legacy_convert.TOOL_DISCLAIMER
-            + """qubes.InputKeyboard\t*\tsys-usb\t@adminvm\task
-qubes.InputKeyboard\t*\tsys-usb-2\t@adminvm\tdeny
+            + """qubes.InputKeyboard\t*\tsys-usb\tdom0\task
+qubes.InputKeyboard\t*\tsys-usb-2\tdom0\tdeny
 qubes.InputMouse\t*\tsys-usb\t@adminvm\tallow
 qubes.InputMouse\t*\tsys-usb-2\t@adminvm\tallow
-qubes.InputTablet\t*\tsys-usb\t@adminvm\task
+qubes.InputTablet\t*\tsys-usb\tdom0\task
 """
         ).split("\n")
     )


### PR DESCRIPTION
The previous behavior of handling "dom0" and "@adminvm" in policies was
inconsistent and let to the problem that you could not specify
target=dom0 default_target=dom0 (or both @adminvm) since one was
translated to @adminvm and the other was alsways expanded to dom0.

Based on the discussion in https://github.com/QubesOS/qubes-issues/issues/9870 we now stop to
translate dom0 (or it's UUID) to @adminvm. The later works as keyword
that is expanded to dom0.

Note this also uncovered some wrong tests (like that "@type:AdminVM"
should not match "dom0").

Closes https://github.com/QubesOS/qubes-issues/issues/9870

---

Depends on #203