### PR TITLE
Restart qrexec-agent on update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PYTHON ?= python3
 export PYTHON CC MAKEFLAGS CFLAGS
 
 SYSLIBDIR ?= /lib
+UNITDIR ?= $(SYSLIBDIR)/systemd/system
 
 help:
 	:
@@ -66,8 +67,8 @@ install-dom0: all-dom0
 	install -t $(DESTDIR)/etc/qubes/policy.d -m 664 policy.d/README
 	install -d $(DESTDIR)/etc/qubes/policy.d/include -m 775
 	install -t $(DESTDIR)/etc/qubes/policy.d/include -m 664 policy.d/include/*
-	install -d $(DESTDIR)/lib/systemd/system -m 755
-	install -t $(DESTDIR)/lib/systemd/system -m 644 systemd/qubes-qrexec-policy-daemon.service
+	install -d $(DESTDIR)$(UNITDIR) -m 755
+	install -t $(DESTDIR)$(UNITDIR) -m 644 systemd/qubes-qrexec-policy-daemon.service
 	install -m 755 -d $(DESTDIR)/usr/lib/tmpfiles.d/
 	install -m 0644 -t $(DESTDIR)/usr/lib/tmpfiles.d/ systemd/qrexec.conf
 .PHONY: install-dom0
@@ -81,8 +82,8 @@ all-vm-selinux:
 
 install-vm: all-vm
 	+$(MAKE) install -C agent
-	install -d $(DESTDIR)/$(SYSLIBDIR)/systemd/system -m 755
-	install -t $(DESTDIR)/$(SYSLIBDIR)/systemd/system -m 644 systemd/qubes-qrexec-agent.service
+	install -d $(DESTDIR)$(UNITDIR) -m 755
+	install -t $(DESTDIR)$(UNITDIR) -m 644 systemd/qubes-qrexec-agent.service
 	install -m 0644 -D qubes-rpc-config/README $(DESTDIR)/etc/qubes/rpc-config/README
 install-vm-selinux:
 	install -m 0644 -D -t $(DESTDIR)/usr/share/selinux/packages selinux/qubes-core-qrexec.pp

--- a/debian/rules
+++ b/debian/rules
@@ -30,8 +30,5 @@ override_dh_auto_install:
 	make install-base
 	make install-vm
 
-override_dh_systemd_start:
-	dh_systemd_start --no-restart-on-upgrade
-
 override_dh_install:
 	dh_install --fail-missing

--- a/rpm_spec/qubes-qrexec-dom0.spec.in
+++ b/rpm_spec/qubes-qrexec-dom0.spec.in
@@ -123,7 +123,7 @@ rm -f %{name}-%{version}
 %{_sysconfdir}/qubes-rpc/policy.include.Remove
 %{_tmpfilesdir}/qrexec.conf
 
-/lib/systemd/system/qubes-qrexec-policy-daemon.service
+%{_unitdir}/qubes-qrexec-policy-daemon.service
 
 %changelog
 @CHANGELOG@

--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -97,6 +97,9 @@ rm -f %{name}-%{version}
 %preun
 %systemd_preun qubes-qrexec-agent.service
 
+%postun
+%systemd_postun_with_restart qubes-qrexec-agent.service
+
 %pre selinux
 %selinux_relabel_pre
 

--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -140,7 +140,7 @@ fi
 /usr/lib/qubes/qrexec-agent
 /usr/lib/qubes/qrexec-client-vm
 /usr/lib/qubes/qrexec_client_vm
-/lib/systemd/system/qubes-qrexec-agent.service
+%{_unitdir}/qubes-qrexec-agent.service
 
 %files selinux
 %{_datadir}/selinux/devel/include/contrib/ipp-qubes-core-qrexec.if


### PR DESCRIPTION
Agent restart is supported since 4.1.0 version, do restart it on update.
This avoids compatibility issues when qrexec-client-vm version is newer
than qrexec-agent itself.