### PR TITLE
Use glib's native asyncio integration when available

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -11,6 +11,7 @@ depends=(
     bash
     glibc
     python
+    python-gobject
     python-setuptools
     pam
     qubes-libvchan

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends:
  dh-python,
  lsb-release,
  python3-setuptools,
- python3-gbulb,
+ python3-gi (>= 3.50.0) | python3-gbulb,
  pandoc,
 Standards-Version: 4.4.0.1
 Homepage: https://www.qubes-os.org

--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -31,15 +31,22 @@ import asyncio
 import importlib.resources
 
 # pylint: disable=import-error,wrong-import-position
+# pylint: disable=wrong-import-order
 import gi
 
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk, Gdk, GdkPixbuf, GLib, Gio
 
-# pylint: enable=import-error
+try:
+    from gi.events import GLibEventLoopPolicy
 
-# pylint: disable=wrong-import-order
-import gbulb
+    HAS_GBULB = False
+except ImportError:
+    import gbulb
+
+    HAS_GBULB = True
+
+# pylint: enable=import-error
 
 from .. import POLICY_AGENT_SOCKET_PATH
 from ..utils import sanitize_domain_name, sanitize_service_name
@@ -508,7 +515,18 @@ class RPCConfirmationWindow:
         self._rpc_window.close()
 
     async def _wait_for_close(self):
-        await gbulb.wait_signal(self._rpc_window, "delete-event")
+        future = asyncio.Future()
+        hnd = None
+
+        def _delete_callback(*k):
+            self._rpc_window.disconnect(hnd)
+            future.set_result(k)
+
+        hnd = self._rpc_window.connect(
+            "delete-event",
+            _delete_callback,
+        )
+        await future
 
     def _show(self):
         self._rpc_window.set_keep_above(True)
@@ -668,10 +686,15 @@ parser.add_argument(
 def main():
     args = parser.parse_args()
 
-    gbulb.install()
+    if HAS_GBULB:
+        # pylint: disable=used-before-assignment
+        gbulb.install()
+    else:
+        asyncio.set_event_loop_policy(GLibEventLoopPolicy())
+    loop = asyncio.get_event_loop()
     agent = PolicyAgent(args.socket_path)
 
-    asyncio.run(agent.run())
+    loop.run_until_complete(agent.run())
 
 
 if __name__ == "__main__":

--- a/rpm_spec/qubes-qrexec.spec.in
+++ b/rpm_spec/qubes-qrexec.spec.in
@@ -47,7 +47,11 @@ BuildRequires:  python%{python3_pkgversion}-rpm-macros
 BuildRequires:  systemd-rpm-macros
 
 Requires:   python%{python3_pkgversion}
+%if 0%{?fedora} < 42
 Requires:   python%{python3_pkgversion}-gbulb
+%else
+Requires:   python%{python3_pkgversion}-gobject >= 3.50.0
+%endif
 %if 0%{?is_opensuse}
 Requires:   python%{python3_pkgversion}-pyinotify
 %else


### PR DESCRIPTION
Glib >= 3.50 has native asyncio integration. When available, use it
instead of gbulb.
This requires few minor changes:
- asyncio.run() doesn't work there (asyncio.set_event_loop() cannot be
  called on the main thread with glib...)
- there is no gbulb.wait_signal() anymore - implement it manually

Based on https://github.com/QubesOS/qubes-core-qrexec/pull/191 by
@CertainLach

QubesOS/qubes-issues#9809