### PR TITLE
policy: ignore (with warning) non-allowed default_target=

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -1314,6 +1314,17 @@ class Ask(ActionType):
             elif is_dom0(default_target):
                 default_target = "dom0"
 
+        if default_target not in targets_for_ask:
+            logging.warning(
+                "warning: policy define default_target=%s at %s:%s "
+                "but it is not amoung allowed targets (%s)",
+                default_target,
+                self.rule.filepath,
+                self.rule.lineno,
+                ", ".join(targets_for_ask),
+            )
+            default_target = None
+
         return request.ask_resolution_type(
             self.rule,
             request,

--- a/qrexec/tests/policy_parser.py
+++ b/qrexec/tests/policy_parser.py
@@ -1835,6 +1835,23 @@ class TC_40_evaluate(ParserTestCase):
             ],
         )
 
+    def test_043_eval_ask_invalid_default_target(self):
+        policy = parser.StringPolicy(
+            policy="""\
+            * * test-vm3 test-vm2 ask default_target=test-vm1"""
+        )
+        with unittest.mock.patch("qrexec.policy.parser.logging") as mock_log:
+            resolution = policy.evaluate(self.gen_req("test-vm3", "test-vm2"))
+        self.assertIsInstance(resolution, parser.AskResolution)
+        self.assertCountEqual(
+            sorted(resolution.targets_for_ask),
+            [
+                "test-vm2",
+            ],
+        )
+        self.assertIsNone(resolution.default_target)
+        mock_log.warning.assert_called_once()
+
     def test_050_eval_resolve_dispvm(self):
         policy = parser.StringPolicy(
             policy="""\


### PR DESCRIPTION
Instead of denying the call with confusing assert, log a warning
explaining the situation but still display the ask prompt, just without
the default target selected. In some (many?) cases, the intention of
default_target= was to have a prompt just to confirm the operation, not
actual target selection - and in those cases, the intended operation
still won't succeed (as the intended target is not allowed). But in some
cases, user may still want choose an alternative target (for example
after renaming a qube)

QubesOS/qubes-issues#9980