### PR TITLE
selinux: fix qrexec-agent restart

### DIFF
--- a/agent/qrexec-agent.c
+++ b/agent/qrexec-agent.c
@@ -1004,4 +1004,6 @@ int main(int argc, char **argv)
     }
 
     libvchan_close(ctrl_vchan);
+
+    unlink(agent_trigger_path);
 }

--- a/selinux/qubes-core-qrexec.te
+++ b/selinux/qubes-core-qrexec.te
@@ -53,6 +53,7 @@ allow qubes_qrexec_agent_t xauth_exec_t:file execute;
 type_transition qubes_qrexec_agent_t qubes_var_run_t:sock_file qubes_qrexec_socket_t "qrexec-agent";
 manage_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_qrexec_socket_t)
 write_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_var_run_t)
+delete_sock_files_pattern(qubes_qrexec_agent_t, qubes_var_run_t, qubes_var_run_t)
 allow domain qubes_qrexec_agent_t:unix_stream_socket { rw_inherited_sock_file_perms ioctl };
 allow qubes_qrexec_agent_t domain:unix_stream_socket connectto;
 allow qubes_qrexec_agent_t file_type:sock_file { rw_sock_file_perms ioctl };


### PR DESCRIPTION
When qrexec-agent restarts, it needs to remove the old socket file before
creating the new one. Let the agent do that when SELinux is enabled.

Fixes QubesOS/qubes-issues#9982

And also, remove the socket on shutdown too.