### PR TITLE
Initialize asyncio event loop before using it

### DIFF
--- a/qrexec/policy/utils.py
+++ b/qrexec/policy/utils.py
@@ -61,7 +61,8 @@ class PolicyCache:
             | pyinotify.IN_MOVED_TO
         )
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
         self.notifier = pyinotify.AsyncioNotifier(
             self.watch_manager, loop, default_proc_fun=PolicyWatcher(self)


### PR DESCRIPTION
Python 3.14 (in Fedora 43) throws RunetimeError if event loop is not initialized before using it.

Resolves: QubesOS/qubes-issues#10188