### PR TITLE
rpm: don't fail posttrans scriptlet when running in chroot/container

### DIFF
--- a/rpm_spec/qubes-qrexec-vm.spec.in
+++ b/rpm_spec/qubes-qrexec-vm.spec.in
@@ -120,7 +120,7 @@ exit 0
 # %%post of this package. Redo the action in %%posttrans
 %systemd_post qubes-qrexec-agent.service
 # and then start it back
-if systemctl is-enabled qubes-qrexec-agent.service >/dev/null 2>&1; then
+if [ -e /run/systemd/system ] && systemctl is-enabled qubes-qrexec-agent.service >/dev/null 2>&1; then
     systemctl start qubes-qrexec-agent.service
 fi
 


### PR DESCRIPTION
Do not fail the RPM transaction if not running installation under
systemd. This specifically applies to containers (CI) and template build
(chroot). While theoretically post-trans scriptlet failure is not fatal,
in practice rpm in Fedora 43 does consider such transaction failed.

QubesOS/qubes-issues#10102