### PR TITLE
policy: make policy_path arg to FilePolicy optional

### DIFF
--- a/qrexec/policy/parser.py
+++ b/qrexec/policy/parser.py
@@ -2046,7 +2046,9 @@ class AbstractFileSystemLoader(AbstractDirectoryLoader, AbstractFileLoader):
     def __init__(
         self,
         *,
-        policy_path: Union[None, pathlib.PurePath, Iterable[pathlib.PurePath]],
+        policy_path: Union[
+            None, pathlib.PurePath, Iterable[pathlib.PurePath]
+        ] = None,
     ) -> None:
         super().__init__()
         if policy_path is None:


### PR DESCRIPTION
It already handles the case of `None` to use default path. Make it
actually optional.

Fixes QubesOS/qubes-issues#10329