### PR TITLE
qrexec-policy-graph: add qube colors

### DIFF
--- a/qrexec/tests/tools/qrexec_legacy_convert.py
+++ b/qrexec/tests/tools/qrexec_legacy_convert.py
@@ -31,6 +31,7 @@ def system_info():
     system_info = {
         "dom0": {
             "icon": "black",
+            "label": "0xffffff",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AdminVM",
@@ -39,6 +40,7 @@ def system_info():
         },
         "work": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -47,6 +49,7 @@ def system_info():
         },
         "personal": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -55,6 +58,7 @@ def system_info():
         },
         "sys-usb": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -63,6 +67,7 @@ def system_info():
         },
         "sys-usb-2": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -71,6 +76,7 @@ def system_info():
         },
         "dvm_template": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": True,
             "guivm": None,
             "type": "AppVM",

--- a/qrexec/tests/tools/qrexec_policy_graph.py
+++ b/qrexec/tests/tools/qrexec_policy_graph.py
@@ -31,6 +31,7 @@ def system_info():
     system_info = {
         "dom0": {
             "icon": "black",
+            "label": "0xffffff",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AdminVM",
@@ -39,6 +40,7 @@ def system_info():
         },
         "work": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -47,6 +49,7 @@ def system_info():
         },
         "personal": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -55,6 +58,7 @@ def system_info():
         },
         "sys-usb": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -63,6 +67,7 @@ def system_info():
         },
         "sys-usb-2": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": False,
             "guivm": None,
             "type": "AppVM",
@@ -71,6 +76,7 @@ def system_info():
         },
         "dvm_template": {
             "icon": "red",
+            "label": "0xcc0000",
             "template_for_dispvms": True,
             "guivm": None,
             "type": "AppVM",
@@ -104,6 +110,8 @@ def test_simple_graph():
             main(["--policy-dir", policy_dir, "--output", output.name])
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=red];
 }
 """
@@ -126,6 +134,8 @@ def test_simple_ask():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=orange];
 }
 """
@@ -151,7 +161,10 @@ def test_simple_service():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=red];
+  "sys-usb" [color = "#cc0000", penwidth = 3];
   "sys-usb" -> "personal" [label="test.Service" color=red];
 }
 """
@@ -177,7 +190,10 @@ def test_simple_service_arg():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=red];
+  "sys-usb" [color = "#cc0000", penwidth = 3];
   "sys-usb" -> "personal" [label="test.Service" color=red];
 }
 """
@@ -202,6 +218,8 @@ def test_simple_service_arg_single():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=red];
 }
 """
@@ -227,6 +245,8 @@ def test_simple_service_no_wildcard():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service" color=red];
 }
 """
@@ -253,6 +273,8 @@ def test_simple_service_no_wildcard_full():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "personal" [color = "#cc0000", penwidth = 3];
   "work" -> "personal" [label="test.Service+arg allow" color=red];
   "work" -> "personal" [label="test.Service+arg2 allow" color=red];
 }
@@ -277,6 +299,8 @@ def test_simple_redirect():
             )
             content = output.read().decode()
             expected = """digraph g {
+  "work" [color = "#cc0000", penwidth = 3];
+  "dom0" [color = "#ffffff", penwidth = 3];
   "work" -> "dom0" [label="test.Service" color=red];
 }
 """

--- a/qrexec/tools/qrexec_policy_graph.py
+++ b/qrexec/tools/qrexec_policy_graph.py
@@ -103,7 +103,7 @@ def handle_single_action(args, action, system_info):
             node_color = system_info["domains"][node]["label"].replace(
                 "0x", "#"
             )
-            node_attributes = f'color = "{node_color}", penwidth = 5'
+            node_attributes = f'color = "{node_color}", penwidth = 3'
         lines.append(f'  "{node}" [{node_attributes}];\n')
 
     # create edges with services as labels

--- a/qrexec/tools/qrexec_policy_graph.py
+++ b/qrexec/tools/qrexec_policy_graph.py
@@ -24,8 +24,6 @@ import pathlib
 
 import sys
 
-import qubesadmin
-
 from .. import POLICYPATH
 from .. import exc
 from .. import utils
@@ -80,7 +78,7 @@ argparser.add_argument(
 )
 
 
-def handle_single_action(args, action, app):
+def handle_single_action(args, action, system_info):
     """Get single policy action and output (or not) lines to add"""
     if args.skip_labels:
         service = ""
@@ -102,7 +100,9 @@ def handle_single_action(args, action, app):
         if node.startswith("@"):  # non-literal qubes
             node_attributes = "style = dotted"
         else:
-            node_color = app.domains[node].label.color.replace("0x", "#")
+            node_color = system_info["domains"][node]["label"].replace(
+                "0x", "#"
+            )
             node_attributes = f'color = "{node_color}", penwidth = 5'
         lines.append(f'  "{node}" [{node_attributes}];\n')
 
@@ -189,8 +189,6 @@ def main(args=None, output=sys.stdout):
     )
     targets.append("@default")
 
-    app = qubesadmin.Qubes()
-
     connections = set()
 
     policy = parser.FilePolicy(policy_path=args.policy_dir)
@@ -230,7 +228,7 @@ def main(args=None, output=sys.stdout):
                 except exc.AccessDenied:
                     continue
 
-                for line in handle_single_action(args, action, app):
+                for line in handle_single_action(args, action, system_info):
                     if line in connections:
                         continue
                     if line:

--- a/qrexec/tools/qrexec_policy_graph.py
+++ b/qrexec/tools/qrexec_policy_graph.py
@@ -24,6 +24,8 @@ import pathlib
 
 import sys
 
+import qubesadmin
+
 from .. import POLICYPATH
 from .. import exc
 from .. import utils
@@ -78,8 +80,8 @@ argparser.add_argument(
 )
 
 
-def handle_single_action(args, action):
-    """Get single policy action and output (or not) a line to add"""
+def handle_single_action(args, action, app):
+    """Get single policy action and output (or not) lines to add"""
     if args.skip_labels:
         service = ""
     else:
@@ -91,25 +93,47 @@ def handle_single_action(args, action):
     if action.rule.action.target:
         target = action.rule.action.target
     if args.target and target not in args.target:
-        return ""
+        return []
+
+    lines = []
+
+    # create nodes for source and target, with colors
+    for node in [action.request.source, target]:
+        if node.startswith("@"):  # non-literal qubes
+            node_attributes = "style = dotted"
+        else:
+            node_color = app.domains[node].label.color.replace("0x", "#")
+            node_attributes = f'color = "{node_color}", penwidth = 5'
+        lines.append(f'  "{node}" [{node_attributes}];\n')
+
+    # create edges with services as labels
     if args.full_output:
         color = "orange" if isinstance(action, parser.AskResolution) else "red"
-        return (
+        lines.append(
             f'  "{action.request.source}" -> "{target}" '
             f'[label="{service} {action.rule.action}" color={color}];\n'
         )
+        return lines
+
     if isinstance(action, parser.AskResolution):
         if args.include_ask:
-            return (
-                f'  "{action.request.source}" -> "{target}" '
-                f'[label="{service}" color=orange];\n'
+            lines.append(
+                (
+                    f'  "{action.request.source}" -> "{target}" '
+                    f'[label="{service}" color=orange];\n'
+                )
             )
+            return lines
     elif isinstance(action, parser.AllowResolution):
-        return (
-            f'  "{action.request.source}" -> "{target}" '
-            f'[label="{service}" color=red];\n'
+        lines.append(
+            (
+                f'  "{action.request.source}" -> "{target}" '
+                f'[label="{service}" color=red];\n'
+            )
         )
-    return ""
+        return lines
+
+    return []
 
 
 def main(args=None, output=sys.stdout):
@@ -165,6 +189,8 @@ def main(args=None, output=sys.stdout):
     )
     targets.append("@default")
 
+    app = qubesadmin.Qubes()
+
     connections = set()
 
     policy = parser.FilePolicy(policy_path=args.policy_dir)
@@ -201,14 +227,15 @@ def main(args=None, output=sys.stdout):
                         system_info=system_info,
                     )
                     action = policy.evaluate(request)
-                    line = handle_single_action(args, action)
+                except exc.AccessDenied:
+                    continue
+
+                for line in handle_single_action(args, action, app):
                     if line in connections:
                         continue
                     if line:
                         output.write(line)
                     connections.add(line)
-                except exc.AccessDenied:
-                    continue
 
     output.write("}\n")
     if args.output:

--- a/qrexec/utils.py
+++ b/qrexec/utils.py
@@ -127,6 +127,7 @@ class SystemInfoEntry(TypedDict):
     default_dispvm: Optional[str]
     power_state: str
     icon: str
+    label: str
     guivm: Optional[str]
     uuid: Optional[str]
     name: str


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#3007. I have not fixed the tests yet, but I believe the rest is ready for feedback.

Code decisions:
  1. Node styling is not organized: Node styling is added as nodes are found instead of being grouped together. It should have no impact on the final graph and was considered as a potentially acceptable trade-off for implementation simplicity.
  2. qubesadmin vs. system_info: The already used system_info did not provide qube colors, therefore it was obtained from qubesadmin.

Styling decisions:
  1. Qube color was added to node borders in case of a literal qube (one that doesn't start with "@"). On non-literal qubes, nodes are dotted because it's not necessarily an individual qube.
  2. The chosen style of coloring borders instead of solid filling made it easier to deal with the inner text (example: black text on black colored qubes).


## Before
![before](https://github.com/user-attachments/assets/76820c18-695f-4d1d-b90d-8b27ea6b7ff0) 

## After
![after](https://github.com/user-attachments/assets/2391c2b1-2ac0-4d57-81c4-8715d228967d)
