### PR TITLE
Increase default connection timeout to 10s

### DIFF
--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
     char *request_id = NULL;
     char *src_domain_name = NULL;
     int src_domain_id = 0; /* if not -c given, the process is run in dom0 */
-    int connection_timeout = 5;
+    int connection_timeout = 10;
     struct service_params svc_params;
     int prepare_ret;
     bool kill = false;


### PR DESCRIPTION
The default 5s timeout is okay for normal operations, but sometimes it's
too short if system is under heavy load or just after resume/unpause
(like a preloaded disposable). Increase the default to 10s.