### PR TITLE
entry: enable Readline-like keyboard shortcuts for qrexec permission prompt

### DIFF
--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -190,7 +190,9 @@ class VMListModeler:
 
             if destination_object.get_has_entry():
                 entry_box = destination_object.get_child()
-                entry_box.get_settings().set_property("gtk-key-theme-name", "Emacs")
+                entry_box.get_settings().set_property(
+                "gtk-key-theme-name", "Emacs"
+)
 
                 area = Gtk.CellAreaBox()
                 area.pack_start(icon_column, False, False, False)

--- a/qrexec/tools/qrexec_policy_agent.py
+++ b/qrexec/tools/qrexec_policy_agent.py
@@ -190,6 +190,7 @@ class VMListModeler:
 
             if destination_object.get_has_entry():
                 entry_box = destination_object.get_child()
+                entry_box.get_settings().set_property("gtk-key-theme-name", "Emacs")
 
                 area = Gtk.CellAreaBox()
                 area.pack_start(icon_column, False, False, False)


### PR DESCRIPTION
Enable Readline-style keyboard shortcuts (Ctrl+A, Ctrl+E, Ctrl+K, Ctrl+U, etc.) for the qrexec permission prompt entry field by applying the GTK Emacs key theme to the widget's settings.

Fixes: https://github.com/QubesOS/qubes-issues/issues/8996