### PR TITLE
qrexec: improve error handling for invalid daemon connection

### DIFF
--- a/daemon/qrexec-client.c
+++ b/daemon/qrexec-client.c
@@ -345,6 +345,9 @@ int main(int argc, char **argv)
                                    wait_connection_end, use_uuid) ? 0 : 137;
         } else {
             s = connect_unix_socket(domname);
+            if (s < 0) {
+                goto cleanup;
+            }
             if (!negotiate_connection_params(s,
                         src_domain_id,
                         just_exec ? MSG_JUST_EXEC : MSG_EXEC_CMDLINE,

--- a/daemon/qrexec-daemon-common.c
+++ b/daemon/qrexec-daemon-common.c
@@ -206,8 +206,13 @@ bool qrexec_execute_vm(const char *target, bool autostart, int remote_domain_id,
     }
 
     s = connect_unix_socket_by_id((unsigned)remote_domain_id);
-    rc = send_service_connect(s, request_id, data_domain, data_port);
-    close(s);
+    if (s < 0) {
+        rc = false;
+    } else {
+        rc = send_service_connect(s, request_id, data_domain, data_port);
+        close(s);
+    }
+
     if (wait_connection_end) {
         /* wait for EOF */
         struct pollfd fds[1] = {


### PR DESCRIPTION
### Details
When `connect_unix_socket()` or `connect_unix_socket_by_id()` fails,
it returns a negative file descriptor. Previously, this value could be
passed directly to functions like `negotiate_connection_params()` and
`send_service_connect()`, which then attempt to operate on it,
leading to `EBADF` ("Bad file descriptor") errors.

This patch validates the socket descriptor at the call sites and
prevents further processing if the connection fails.

### Result
- Avoids passing invalid file descriptors to downstream functions
- Prevents misleading `EBADF` errors during connection setup

Fixes QubesOS/qubes-issues#10792