### PR TITLE
Reject uppercase policy file names in admin API

### DIFF
--- a/qrexec/policy/admin.py
+++ b/qrexec/policy/admin.py
@@ -307,10 +307,10 @@ class PolicyAdmin:
     # helpers
 
     def _get_path(self, arg: str, dir_path: str, suffix: str) -> Path:
-        if not re.compile(r"^[\w-]+$").match(arg):
+        if not re.compile(r"^[a-z0-9_-]+$").match(arg):
             raise PolicyAdminInvalidFileNameException(
                 f"Invalid policy file name: {arg}\n"
-                "Names must contain only alphanumeric characters, "
+                "Names must contain only lowercase latin letters, digits, "
                 "underscore and hyphen."
             )
         path = dir_path / (arg + suffix)

--- a/qrexec/tests/policy/admin.py
+++ b/qrexec/tests/policy/admin.py
@@ -102,6 +102,11 @@ def test_api_get(policy_dir, api):
     with pytest.raises(
         PolicyAdminInvalidFileNameException, match="Invalid policy file"
     ):
+        api.handle_request("policy.Get", "Uppercase", b"")
+
+    with pytest.raises(
+        PolicyAdminInvalidFileNameException, match="Invalid policy file"
+    ):
         api.handle_request("policy.include.Get", "..", b"")
 
     with pytest.raises(
@@ -116,6 +121,15 @@ def test_api_get(policy_dir, api):
 def test_api_replace(policy_dir, api):
     api.handle_request("policy.Replace", "file1", b"any\n")
     assert (policy_dir / "file1.policy").read_text() == ""
+
+    api.handle_request("policy.Replace", "valid-name_1", b"any\n")
+    assert (policy_dir / "valid-name_1.policy").read_text() == ""
+
+    with pytest.raises(
+        PolicyAdminInvalidFileNameException, match="Invalid policy file"
+    ):
+        api.handle_request("policy.Replace", "Uppercase", b"any\n")
+    assert not (policy_dir / "Uppercase.policy").exists()
 
     api.handle_request("policy.Replace", "file1", b"any\nrpc.Name * * * deny")
     assert (policy_dir / "file1.policy").read_text() == "rpc.Name * * * deny"


### PR DESCRIPTION
## Summary

The policy admin API validates proposed file names more permissively than the
policy loader will accept, so a caller with `policy.Replace` access can persist
a file the loader then refuses — wedging every later policy load and denying all
qrexec calls system-wide.

## Changes

- **Root cause:** `_get_path()` validated names with `^[\w-]+$`, which allows
  uppercase, while the loader's `FILENAME_ALLOWED_CHARSET` (`parser.py`) has no
  uppercase and rejects the whole directory on the first offending file. A
  `policy.Replace` of e.g. `Foo.policy` passes validation (`ValidateParser` loads
  the new content from an in-memory override, so the on-disk name is never
  charset-checked), lands on disk, then makes every subsequent `FilePolicy` load
  raise `AccessDenied` — a persistent, global qrexec DoS. `policy.Remove` cannot
  recover it either, since its own validation re-scans the now-poisoned directory.
  Tighten the regex to `^[a-z0-9_-]+$`.
- Add regression tests: `policy.Get`/`policy.Replace` reject an uppercase name,
  `policy.Replace` writes no file when rejected, and valid `[a-z0-9_-]` names are
  still accepted.

## Testing

- `python -m pytest qrexec/tests/policy/admin.py` — 10 passed.
- Regression evidence: restoring the pre-fix `^[\w-]+$` makes the new assertions
  fail (`test_api_get`, `test_api_replace` — 2 failed, 8 passed).

## Notes for reviewers

- The new charset is a strict subset of the loader's `FILENAME_ALLOWED_CHARSET`:
  it drops only `.`, which `_get_path` never accepted anyway (the API appends the
  `.policy` suffix itself). No previously-valid name regresses; the only names
  newly rejected are exactly those the loader would refuse.
- **Decision:** `_get_path` is shared, so this also rejects uppercase in
  `policy.include.*` names, which the loader does not charset-check. Kept uniform
  intentionally — happy to scope it to `.policy`-only if you'd prefer.

## AI disclosure

Per the project's [policy on using AI in contributions](https://doc.qubes-os.org/en/latest/introduction/contributing.html#using-ai-in-contributions):
this contribution was developed with generative AI assistance (Anthropic's
Claude, via Claude Code). AI was used to identify the issue, draft the fix and
regression tests, and write this description. As the submitting author I am
fully accountable for this content: I have reviewed the diff and its root-cause
rationale, and confirmed the tests pass and fail against the pre-fix code as
described above.
