### PR TITLE
ci: use common job template for pylint

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,6 @@ include:
     - sudo make -C ~/qubes-core-vchan-socket install LIBDIR=/usr/lib64
     - pip3 install --user --quiet -r ci/requirements.txt
 
-checks:pylint:
-  extends: .qrexec_checks
-  script:
-    - python3 -m pylint qrexec
 
 checks:tests:
   extends: .qrexec_checks
@@ -50,5 +46,7 @@ checks:fuzz:
 lint:
   extends: .lint
   variables:
-    SKIP_PYLINT: 1
-    DIR: .
+    DIR: qrexec
+  before_script:
+  - !reference [.lint, before_script]
+  - *before-script

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,7 +9,7 @@
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=tests
+ignore-paths=qrexec/tests
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.


### PR DESCRIPTION
Use pylint from '.lint' job template, to include common patches.
